### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build/Release
 
+permissions:
+  contents: write
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/bluemoonfoundry/vangard-renpy-ide/security/code-scanning/2](https://github.com/bluemoonfoundry/vangard-renpy-ide/security/code-scanning/2)

In general, the fix is to explicitly declare a `permissions` block for the workflow or for the specific job so that the `GITHUB_TOKEN` used in this workflow has only the minimal required scopes instead of inheriting broad defaults. Since this workflow reads code and uses `GITHUB_TOKEN` potentially for release publishing via Electron Builder, we should start with `contents: read` at the workflow level, and then, if releases are actually created, elevate to `contents: write` (the minimal permission required for creating releases). Because we cannot see the package.json/electron-builder config, we should conservatively allow `contents: write` to avoid breaking existing release publishing behavior.

The single best way to fix this without changing functionality is to add a `permissions` block at the root level of `.github/workflows/build.yml`, just below `name: Build/Release` (or at least above `jobs:`), specifying `contents: write`. This ensures all jobs in the workflow (currently just `build`) have that permission and no others. We do not need any imports or other definitions; only the YAML needs to be updated. No other lines or behavior need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
