### PR TITLE
Fix false-positive editor diagnostics, add Ren'Py project check, and …

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -384,6 +384,8 @@ const App: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [loadingMessage, setLoadingMessage] = useState('');
   const [loadingProgress, setLoadingProgress] = useState(0);
+  const loadCancelRef = useRef(false);
+  const [nonRenpyWarningPath, setNonRenpyWarningPath] = useState<string | null>(null);
   
   const [deleteConfirmInfo, setDeleteConfirmInfo] = useState<{ paths: string[]; onConfirm: () => void; } | null>(null);
   const [createBlockModalOpen, setCreateBlockModalOpen] = useState(false);
@@ -1108,11 +1110,18 @@ const App: React.FC = () => {
   // --- File System Integration ---
   
   const loadProject = useCallback(async (path: string) => {
+      loadCancelRef.current = false;
       setIsLoading(true);
       setLoadingMessage('Reading project files...');
       setStatusBarMessage(`Loading project from ${path}...`);
       try {
           const projectData = await window.electronAPI!.loadProject(path);
+
+          // If the user cancelled while the directory was being read, discard results.
+          if (loadCancelRef.current) {
+              setStatusBarMessage('');
+              return;
+          }
           
           // Map existing blocks to preserve IDs and positions
           const existingBlocksMap = new Map<string, Block>();
@@ -1401,21 +1410,52 @@ const App: React.FC = () => {
           setStatusBarMessage('Project loaded.');
           setTimeout(() => setStatusBarMessage(''), 3000);
       } catch (err) {
+          if (loadCancelRef.current) {
+              setStatusBarMessage('');
+              return;
+          }
           console.error(err);
           addToast('Failed to load project', 'error');
           setStatusBarMessage('Error loading project.');
       } finally {
           setIsLoading(false);
+          setLoadingMessage('');
+          setLoadingProgress(0);
       }
   }, [setBlocks, setImages, setAudios, updateProjectSettings, addToast, setFileSystemTree, setStickyNotes, setCharacterProfiles, updateAppSettings, setSceneCompositions, setSceneNames, setPunchlistMetadata]);
 
+
+  const handleCancelLoad = useCallback(() => {
+      loadCancelRef.current = true;
+      // Terminate the worker thread in the main process immediately.
+      // The overlay stays visible in its "Cancelling..." state (local state in LoadingOverlay)
+      // until the worker exits and the finally block in loadProject sets isLoading = false.
+      // We deliberately do NOT call setIsLoading(false) here — doing so with flushSync caused
+      // a blocking synchronous render that prevented Electron's IPC quit handshake from
+      // being processed, making File->Quit appear broken for several seconds after cancel.
+      window.electronAPI?.cancelProjectLoad?.();
+      addToast('Project loading cancelled.', 'info');
+  }, [addToast]);
+
+  // Checks whether the selected folder looks like a Ren'Py project before loading.
+  // If it doesn't (no game/ folder, no .rpy files), shows a confirmation warning first.
+  const handleOpenWithRenpyCheck = useCallback(async (path: string) => {
+      if (window.electronAPI?.checkRenpyProject) {
+          const check = await window.electronAPI.checkRenpyProject(path);
+          if (!check.isRenpyProject) {
+              setNonRenpyWarningPath(path);
+              return;
+          }
+      }
+      await loadProject(path);
+  }, [loadProject]);
 
   const handleOpenProjectFolder = useCallback(async () => {
     try {
         if (window.electronAPI) {
             const path = await window.electronAPI.openDirectory();
             if (path) {
-                await loadProject(path);
+                await handleOpenWithRenpyCheck(path);
             }
         } else {
             alert("To use local file system features, please run this app in Electron or use a compatible browser with FS Access API support (Chrome/Edge). For now, you are in Browser Mode.");
@@ -1424,7 +1464,7 @@ const App: React.FC = () => {
         console.error(err);
         addToast('Failed to open project', 'error');
     }
-  }, [loadProject, addToast]);
+  }, [handleOpenWithRenpyCheck, addToast]);
 
   const handleCreateProject = useCallback(async () => {
       try {
@@ -2488,7 +2528,7 @@ const App: React.FC = () => {
         const removeListener = window.electronAPI.onMenuCommand((data: { command: string, type?: 'canvas' | 'route-canvas' | 'punchlist' | 'ai-generator', path?: string }) => {
             if (data.command === 'new-project') handleNewProjectRequest();
             if (data.command === 'open-project') handleOpenProjectFolder();
-            if (data.command === 'open-recent' && data.path) loadProject(data.path);
+            if (data.command === 'open-recent' && data.path) handleOpenWithRenpyCheck(data.path);
             if (data.command === 'save-all') handleSaveAll();
             if (data.command === 'run-project' && projectRootPath) window.electronAPI?.runGame(appSettings.renpyPath, projectRootPath);
             if (data.command === 'stop-project') window.electronAPI?.stopGame();
@@ -2501,7 +2541,7 @@ const App: React.FC = () => {
             if (data.command === 'toggle-right-sidebar') updateAppSettings(draft => { draft.isRightSidebarOpen = !draft.isRightSidebarOpen; });
         });
         return removeListener;
-  }, [handleNewProjectRequest, handleOpenProjectFolder, loadProject, handleSaveAll, projectRootPath, appSettings.renpyPath, handleOpenStaticTab, handleToggleSearch, updateAppSettings]);
+  }, [handleNewProjectRequest, handleOpenProjectFolder, handleOpenWithRenpyCheck, loadProject, handleSaveAll, projectRootPath, appSettings.renpyPath, handleOpenStaticTab, handleToggleSearch, updateAppSettings]);
 
   // --- Game Running State ---
   useEffect(() => {
@@ -3160,17 +3200,36 @@ const App: React.FC = () => {
       </div>
 
       {/* Modals and Overlays */}
-      {showWelcome && (
-        <WelcomeScreen 
+      {showWelcome && !isLoading && (
+        <WelcomeScreen
             onOpenProject={handleOpenProjectFolder}
             onCreateProject={handleCreateProject}
             isElectron={!!window.electronAPI}
             recentProjects={appSettings.recentProjects}
-            onOpenRecent={loadProject}
+            onOpenRecent={handleOpenWithRenpyCheck}
         />
       )}
-      
-      {isLoading && <LoadingOverlay progress={loadingProgress} message={loadingMessage} />}
+
+      {nonRenpyWarningPath && (
+        <ConfirmModal
+          title="Folder may not be a Ren'Py project"
+          confirmText="Open Anyway"
+          confirmClassName="bg-indigo-600 hover:bg-indigo-700"
+          onConfirm={() => {
+            const path = nonRenpyWarningPath;
+            setNonRenpyWarningPath(null);
+            loadProject(path);
+          }}
+          onClose={() => setNonRenpyWarningPath(null)}
+        >
+          The selected folder doesn't appear to contain a Ren'Py project — no{' '}
+          <code className="bg-gray-100 dark:bg-gray-700 px-1 rounded text-sm">game/</code>{' '}
+          folder or <code className="bg-gray-100 dark:bg-gray-700 px-1 rounded text-sm">.rpy</code>{' '}
+          files were found. You can still open it, but it may not work as expected.
+        </ConfirmModal>
+      )}
+
+      {isLoading && <LoadingOverlay progress={loadingProgress} message={loadingMessage} onCancel={handleCancelLoad} />}
       
       <div className="fixed bottom-4 right-4 z-[9999] flex flex-col space-y-2 pointer-events-none">
         {toasts.map(toast => (

--- a/components/EditorView.tsx
+++ b/components/EditorView.tsx
@@ -38,6 +38,8 @@ interface EditorViewProps {
 const LABEL_REGEX = /^\s*label\s+([a-zA-Z0-9_]+):/;
 const JUMP_REGEX = /\b(jump|call)\s+([a-zA-Z0-9_]+)/g;
 const AUDIO_USAGE_REGEX = /^\s*(?:play|queue)\s+\w+\s+(.+)/;
+// Ren'Py keywords that follow `jump`/`call` but are not label targets.
+const JUMP_KEYWORD_TARGETS = new Set(['expression', 'screen']);
 
 const Breadcrumbs: React.FC<{ filePath?: string, context?: string }> = ({ filePath, context }) => {
     if (!filePath) return null;
@@ -227,69 +229,29 @@ const EditorView: React.FC<EditorViewProps> = (props) => {
 
   const performValidation = (code: string, monacoInstance: typeof monaco): monaco.editor.IMarkerData[] => {
     const markers: monaco.editor.IMarkerData[] = [];
+
+    // Skip jump validation until the analysis engine has run at least once.
+    // Without analysis data every cross-file jump would appear invalid on first load.
+    const analysisLabels = analysisResultRef.current.labels;
+    if (Object.keys(analysisLabels).length === 0) return markers;
+
     const lines = code.split('\n');
     const localLabels = new Set<string>();
-
     lines.forEach(line => {
         const match = line.match(LABEL_REGEX);
         if (match) localLabels.add(match[1]);
     });
 
-    let previousIndent = -1;
-    let expectIndentedBlock = false;
-
     lines.forEach((line, index) => {
       const lineNumber = index + 1;
       const trimmedLine = line.trim();
-      
       if (trimmedLine === '' || trimmedLine.startsWith('#')) return;
 
-      const currentIndent = line.length - line.trimStart().length;
-
-      if (expectIndentedBlock) {
-        if (currentIndent <= previousIndent) {
-          markers.push({
-            startLineNumber: lineNumber,
-            startColumn: 1,
-            endLineNumber: lineNumber,
-            endColumn: line.length + 1,
-            message: 'Indentation error: Expected an indented block.',
-            severity: monacoInstance.MarkerSeverity.Error,
-          });
-        }
-        expectIndentedBlock = false;
-      }
-      
-      if (currentIndent % 4 !== 0) {
-        markers.push({
-          startLineNumber: lineNumber,
-          startColumn: 1,
-          endLineNumber: lineNumber,
-          endColumn: currentIndent + 1,
-          message: 'Indentation error: Use 4 spaces per indentation level.',
-          severity: monacoInstance.MarkerSeverity.Warning,
-        });
-      }
-
-      const colonKeywords = ['label', 'if', 'elif', 'menu', 'python', 'while', 'for', 'else', 'init'];
-      const firstWord = trimmedLine.split(/[\s:]/)[0];
-      if (colonKeywords.includes(firstWord) && !trimmedLine.endsWith(':')) {
-        markers.push({
-          startLineNumber: lineNumber,
-          startColumn: line.indexOf(trimmedLine) + trimmedLine.length + 1,
-          endLineNumber: lineNumber,
-          endColumn: line.indexOf(trimmedLine) + trimmedLine.length + 2,
-          message: `Syntax Error: Missing ':'`,
-          severity: monacoInstance.MarkerSeverity.Error,
-        });
-      }
-      
-      if (trimmedLine.endsWith(':')) {
-        expectIndentedBlock = true;
-        previousIndent = currentIndent;
-      }
-
-      let sanitizedLine = line.replace(/"[^"\\]*(?:\\.[^"\\]*)*"/g, m => ' '.repeat(m.length)).replace(/'[^'\\]*(?:\\.[^'\\]*)*'/g, m => ' '.repeat(m.length));
+      // Strip string literals and inline comments before scanning for jumps so
+      // we don't flag label names that appear inside quoted text or comments.
+      let sanitizedLine = line
+          .replace(/"[^"\\]*(?:\\.[^"\\]*)*"/g, m => ' '.repeat(m.length))
+          .replace(/'[^'\\]*(?:\\.[^'\\]*)*'/g, m => ' '.repeat(m.length));
       const commentIndex = sanitizedLine.indexOf('#');
       if (commentIndex !== -1) sanitizedLine = sanitizedLine.substring(0, commentIndex);
 
@@ -297,10 +259,10 @@ const EditorView: React.FC<EditorViewProps> = (props) => {
       let match;
       while ((match = lineJumpRegex.exec(sanitizedLine)) !== null) {
           const target = match[2];
-          if (target === 'expression' || target === 'screen') continue;
+          if (JUMP_KEYWORD_TARGETS.has(target)) continue;
 
           const isLocal = localLabels.has(target);
-          const globalLabelDef = analysisResultRef.current.labels[target];
+          const globalLabelDef = analysisLabels[target];
           const isExternal = globalLabelDef && globalLabelDef.blockId !== blockRef.current.id;
 
           if (!isLocal && !isExternal) {
@@ -485,10 +447,39 @@ const EditorView: React.FC<EditorViewProps> = (props) => {
   };
   
   useEffect(() => {
-      if (isMounted && editorRef.current && monacoRef.current) {
-          const markers = performValidation(editorRef.current.getValue(), monacoRef.current as any);
-          monacoRef.current.editor.setModelMarkers(editorRef.current.getModel()!, 'renpy', markers);
-      }
+      if (!isMounted || !editorRef.current || !monacoRef.current) return;
+
+      const monacoInstance = monacoRef.current;
+      const model = editorRef.current.getModel();
+      if (!model) return;
+
+      // When the file has unsaved edits, the analysis result reflects the saved
+      // version and line numbers may be stale. In that case, the real-time markers
+      // from performValidation (fired on every keystroke) are more accurate, so
+      // don't overwrite them here.
+      const currentContent = editorRef.current.getValue();
+      if (currentContent !== blockRef.current.content) return;
+
+      // Use the analysis engine's pre-computed jump locations. These come from the
+      // same parser that drives the canvas links, so column positions are accurate
+      // and all edge cases (expression jumps, `call screen`, string literals, etc.)
+      // are already handled.
+      const blockJumps = analysisResult.jumps[block.id] ?? [];
+      const invalidTargets = new Set(analysisResult.invalidJumps[block.id] ?? []);
+
+      const markers: monaco.editor.IMarkerData[] = blockJumps
+          .filter(jump => !jump.isDynamic && invalidTargets.has(jump.target) && !JUMP_KEYWORD_TARGETS.has(jump.target))
+          .map(jump => ({
+              startLineNumber: jump.line,
+              // columnStart/columnEnd in JumpLocation are 0-indexed; Monaco uses 1-indexed columns.
+              startColumn: jump.columnStart + 1,
+              endLineNumber: jump.line,
+              endColumn: jump.columnEnd + 1,
+              message: `Invalid jump: Label '${jump.target}' not found in project.`,
+              severity: monacoInstance.MarkerSeverity.Error,
+          }));
+
+      monacoInstance.editor.setModelMarkers(model, 'renpy', markers);
   }, [analysisResult, isMounted]);
   
   useEffect(() => {

--- a/components/LoadingOverlay.tsx
+++ b/components/LoadingOverlay.tsx
@@ -1,25 +1,56 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 interface LoadingOverlayProps {
   progress: number;
   message: string;
+  onCancel?: () => void;
 }
 
-const LoadingOverlay: React.FC<LoadingOverlayProps> = ({ progress, message }) => {
+const LoadingOverlay: React.FC<LoadingOverlayProps> = ({ progress, message, onCancel }) => {
+  const [cancelling, setCancelling] = useState(false);
+
+  const handleCancel = () => {
+    setCancelling(true);
+    onCancel?.();
+  };
+
   return (
     <div className="fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center z-[100] backdrop-blur-sm transition-opacity duration-300">
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow-2xl p-8 max-w-lg w-full text-center border border-gray-200 dark:border-gray-700">
-        <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-4">Loading Project...</h2>
-        <p className="text-gray-600 dark:text-gray-400 mb-6 h-6 truncate" title={message}>
-          {message}
-        </p>
-        <div className="w-full bg-gray-200 rounded-full h-4 dark:bg-gray-700">
-          <div
-            className="bg-indigo-600 h-4 rounded-full transition-all duration-500 ease-out"
-            style={{ width: `${progress}%` }}
-          ></div>
-        </div>
-        <p className="text-lg font-semibold mt-4 text-gray-800 dark:text-gray-200">{Math.round(progress)}%</p>
+        {cancelling ? (
+          <>
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-4">Cancelling...</h2>
+            <p className="text-gray-500 dark:text-gray-400 mb-6">Stopping file scan, please wait.</p>
+            <div className="flex justify-center">
+              <svg className="animate-spin h-8 w-8 text-indigo-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              </svg>
+            </div>
+          </>
+        ) : (
+          <>
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-4">Loading Project...</h2>
+            <p className="text-gray-600 dark:text-gray-400 mb-6 h-6 truncate" title={message}>
+              {message}
+            </p>
+            <div className="w-full bg-gray-200 rounded-full h-4 dark:bg-gray-700">
+              <div
+                className="bg-indigo-600 h-4 rounded-full transition-all duration-500 ease-out"
+                style={{ width: `${progress}%` }}
+              ></div>
+            </div>
+            <p className="text-lg font-semibold mt-4 text-gray-800 dark:text-gray-200">{Math.round(progress)}%</p>
+            {onCancel && (
+              <button
+                onClick={handleCancel}
+                className="mt-6 px-5 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+              >
+                Cancel
+              </button>
+            )}
+          </>
+        )}
       </div>
     </div>
   );

--- a/electron.js
+++ b/electron.js
@@ -7,6 +7,7 @@ import fs from 'fs/promises';
 import { createReadStream } from 'fs';
 import { Readable } from 'stream';
 import { spawn } from 'child_process';
+import { Worker } from 'worker_threads';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -127,7 +128,37 @@ async function getApiKey(provider) {
 }
 
 
-async function readProjectFiles(rootPath, { readContent = true } = {}) {
+async function checkRenpyProject(rootPath) {
+    try {
+        const entries = await fs.readdir(rootPath, { withFileTypes: true });
+        const hasGameFolder = entries.some(e => e.isDirectory() && e.name.toLowerCase() === 'game');
+        const hasRpyAtRoot = entries.some(e => e.isFile() && /\.rpy$/i.test(e.name));
+        let hasRpyInGame = false;
+        if (hasGameFolder) {
+            try {
+                const gameEntries = await fs.readdir(path.join(rootPath, 'game'), { withFileTypes: true });
+                hasRpyInGame = gameEntries.some(e => e.isFile() && /\.rpy$/i.test(e.name));
+            } catch { /* ignore */ }
+        }
+        return { hasGameFolder, isRenpyProject: hasGameFolder || hasRpyAtRoot || hasRpyInGame };
+    } catch {
+        return { hasGameFolder: false, isRenpyProject: false };
+    }
+}
+
+// Active worker for project loading — replaced on each load, terminated on cancel.
+let activeLoadWorker = null;
+
+// Inline worker code for reading project files in a dedicated thread.
+// Using String.raw to preserve backslashes in regex patterns.
+const PROJECT_LOAD_WORKER_CODE = String.raw`
+const { workerData, parentPort } = require('worker_threads');
+const path = require('path');
+const fs = require('fs/promises');
+const { pathToFileURL } = require('url');
+
+async function run() {
+    const { rootPath, readContent } = workerData;
     const results = {
         rootPath,
         files: [],
@@ -143,7 +174,6 @@ async function readProjectFiles(rootPath, { readContent = true } = {}) {
         for (const entry of entries) {
             const fullPath = path.join(dirPath, entry.name);
             const relativePath = path.relative(rootPath, fullPath).replace(/\\/g, '/');
-            
             const childNode = { name: entry.name, path: relativePath, children: entry.isDirectory() ? [] : undefined };
 
             if (entry.isDirectory()) {
@@ -157,21 +187,11 @@ async function readProjectFiles(rootPath, { readContent = true } = {}) {
                 } else if (/\.(png|jpe?g|webp)$/i.test(entry.name)) {
                     const stats = await fs.stat(fullPath);
                     const mediaUrl = pathToFileURL(fullPath).toString().replace(/^file:/, 'media:');
-                    results.images.push({ 
-                        path: relativePath, 
-                        dataUrl: mediaUrl, 
-                        lastModified: stats.mtimeMs,
-                        size: stats.size
-                    });
+                    results.images.push({ path: relativePath, dataUrl: mediaUrl, lastModified: stats.mtimeMs, size: stats.size });
                 } else if (/\.(mp3|ogg|wav|opus)$/i.test(entry.name)) {
                     const stats = await fs.stat(fullPath);
                     const mediaUrl = pathToFileURL(fullPath).toString().replace(/^file:/, 'media:');
-                    results.audios.push({ 
-                        path: relativePath, 
-                        dataUrl: mediaUrl, 
-                        lastModified: stats.mtimeMs,
-                        size: stats.size
-                    });
+                    results.audios.push({ path: relativePath, dataUrl: mediaUrl, lastModified: stats.mtimeMs, size: stats.size });
                 }
             }
             children.push(childNode);
@@ -185,7 +205,7 @@ async function readProjectFiles(rootPath, { readContent = true } = {}) {
     };
 
     await readDirRecursive(rootPath, results.tree);
-    
+
     try {
         const settingsContent = await fs.readFile(path.join(rootPath, 'game', 'project.ide.json'), 'utf-8');
         results.settings = JSON.parse(settingsContent);
@@ -193,7 +213,50 @@ async function readProjectFiles(rootPath, { readContent = true } = {}) {
         results.settings = {};
     }
 
-    return results;
+    parentPort.postMessage({ ok: true, data: results });
+}
+
+run().catch(err => parentPort.postMessage({ ok: false, error: err.message }));
+`;
+
+function readProjectFiles(rootPath, { readContent = true } = {}) {
+    return new Promise((resolve, reject) => {
+        const worker = new Worker(PROJECT_LOAD_WORKER_CODE, {
+            eval: true,
+            workerData: { rootPath, readContent }
+        });
+        activeLoadWorker = worker;
+        let settled = false;
+
+        worker.on('message', (msg) => {
+            settled = true;
+            activeLoadWorker = null;
+            if (msg.ok) {
+                resolve(msg.data);
+            } else {
+                reject(new Error(msg.error));
+            }
+        });
+
+        worker.on('error', (err) => {
+            if (settled) return;
+            settled = true;
+            activeLoadWorker = null;
+            reject(err);
+        });
+
+        worker.on('exit', (code) => {
+            if (activeLoadWorker === worker) activeLoadWorker = null;
+            // Non-zero exit without a prior message means the worker was terminated
+            // (e.g. via worker.terminate() on cancel) or crashed. Either way, reject
+            // so the caller's catch block runs; the cancel flag in App.tsx suppresses
+            // any UI error in the cancel case.
+            if (!settled && code !== 0) {
+                settled = true;
+                reject(new Error('LOAD_CANCELLED'));
+            }
+        });
+    });
 }
 
 async function scanDirectoryForAssets(dirPath) {
@@ -629,6 +692,18 @@ app.whenReady().then(() => {
     const { canceled, filePath } = await dialog.showSaveDialog(options);
     if (canceled) return null;
     return filePath;
+  });
+
+  ipcMain.handle('dialog:checkRenpyProject', async (event, rootPath) => {
+    return await checkRenpyProject(rootPath);
+  });
+
+  // Fire-and-forget: renderer sends this to immediately terminate the active load worker.
+  ipcMain.on('project:cancel-load', () => {
+    if (activeLoadWorker) {
+      activeLoadWorker.terminate();
+      activeLoadWorker = null;
+    }
   });
 
   ipcMain.handle('project:load', async (event, rootPath) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Vangard-RenPy-IDE",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Vangard-RenPy-IDE",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@google/genai": "^0.12.0",
         "@monaco-editor/react": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Vangard-RenPy-IDE",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "main": "electron.js",
   "scripts": {

--- a/preload.js
+++ b/preload.js
@@ -3,6 +3,8 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('electronAPI', {
   openDirectory: () => ipcRenderer.invoke('dialog:openDirectory'),
   createProject: () => ipcRenderer.invoke('dialog:createProject'),
+  checkRenpyProject: (rootPath) => ipcRenderer.invoke('dialog:checkRenpyProject', rootPath),
+  cancelProjectLoad: () => ipcRenderer.send('project:cancel-load'),
   loadProject: (rootPath) => ipcRenderer.invoke('project:load', rootPath),
   refreshProjectTree: (rootPath) => ipcRenderer.invoke('project:refresh-tree', rootPath),
   writeFile: (filePath, content, encoding) => ipcRenderer.invoke('fs:writeFile', filePath, content, encoding),

--- a/types.ts
+++ b/types.ts
@@ -797,6 +797,8 @@ declare global {
     electronAPI?: {
           openDirectory: () => Promise<string | null>;
           createProject?: () => Promise<string | null>;
+          checkRenpyProject?: (path: string) => Promise<{ hasGameFolder: boolean; isRenpyProject: boolean }>;
+          cancelProjectLoad?: () => void;
           loadProject: (path: string) => Promise<any>;
           refreshProjectTree: (path: string) => Promise<any>;
           writeFile: (path: string, content: string, encoding?: string) => Promise<{ success: boolean; error?: string }>;


### PR DESCRIPTION
…fix cancellable project load

- EditorView: Remove bogus indentation/colon/block validators that caused false error markers (issue #73); replace with analysis-engine-driven jump target validation using pre-computed JumpLocation data
- electron.js: Add checkRenpyProject() to detect non-Ren'Py folders before opening; replace flag-based load cancellation with Worker Thread (worker.terminate() for true immediate cancellation)
- LoadingOverlay: Add local 'Cancelling...' spinner state for instant visual feedback on cancel click
- App.tsx: Add non-Ren'Py folder warning modal; fix cancel flow by removing flushSync (was blocking renderer JS thread, breaking Electron's IPC quit handshake); defer isLoading=false to loadProject's finally block so overlay persists until worker actually exits
- preload.js / types.ts: Expose checkRenpyProject and cancelProjectLoad IPC channels