### PR TITLE
Add matrixcolor preset popover and full visual effects suite to Scene Composer (closes #119)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4048,6 +4048,7 @@ const App: React.FC = () => {
         canRedo={canRedo}
         undo={undo}
         redo={redo}
+        hideUndoRedo={openTabs.find(t => t.id === activeTabId)?.type === 'scene-composer'}
         addBlock={() => setCreateBlockModalOpen(true)}
         handleTidyUp={handleActiveCanvasTidyUp}
         handleSave={handleSaveAll}

--- a/DemoProject/game/project.ide.json
+++ b/DemoProject/game/project.ide.json
@@ -1,6 +1,4 @@
 {
-  "enableAiFeatures": false,
-  "selectedModel": "gemini-2.5-flash",
   "draftingMode": true,
   "storyCanvasLayoutMode": "flow-lr",
   "storyCanvasGroupingMode": "none",
@@ -11,14 +9,14 @@
   "routeCanvasLayoutVersion": 2,
   "routeCanvasLayoutWasUserAdjusted": false,
   "storyElementsTabState": {
-    "activeTab": "storyData",
-    "activeSubTab": "characters"
+    "activeTab": "assets",
+    "activeSubTab": "images"
   },
-  "storyCanvasLayoutFingerprint": "v2;mode=flow-lr;group=none;blocks=game/characters.rpy:320x200|game/debug_placeholders.rpy:320x200|game/gui.rpy:320x200|game/options.rpy:320x200|game/scenes/RopedCovenant.rpy:320x200|game/scenes/stage1/TestScript.rpy:320x200|game/scenes/stage1/stage1_announcement.rpy:320x200|game/scenes/stage1/stage1_arrival.rpy:320x200|game/scenes/stage1/stage1_choice.rpy:320x200|game/scenes/stage1/stage1_evening.rpy:320x200|game/scenes/stage1/stage1_library_notice.rpy:320x200|game/scenes/stage1/stage1_meet_h.rpy:320x200|game/scenes/stage1/stage1_meet_s.rpy:320x200|game/scenes/stage1/stage1_rumors.rpy:320x200|game/scenes/stage2/stage2_begin.rpy:320x200|game/scenes/stage2/stage2_converge.rpy:320x200|game/scenes/stage2/stage2_library_clue.rpy:320x200|game/scenes/stage2/stage2_library_path.rpy:320x200|game/scenes/stage2/stage2_occult_path.rpy:320x200|game/scenes/stage2/stage2_social_clue.rpy:320x200|game/scenes/stage2/stage2_social_path.rpy:320x200|game/scenes/stage2/stage2_tech_clue.rpy:320x200|game/scenes/stage2/stage2_tech_path.rpy:320x200|game/scenes/stage3/stage3_begin.rpy:320x200|game/scenes/stage3/stage3_night.rpy:320x200|game/scenes/stage3/stage3_partnership.rpy:320x200|game/scenes/stage3/stage3_revelation.rpy:320x200|game/scenes/stage3/stage3_trust_h.rpy:320x200|game/scenes/stage3/stage3_trust_k.rpy:320x200|game/scenes/stage3/stage3_trust_l.rpy:320x200|game/scenes/stage3/stage3_trust_m.rpy:320x200|game/scenes/stage3/stage3_trust_y.rpy:320x200|game/scenes/stage4/stage4_analyze_clues.rpy:320x200|game/scenes/stage4/stage4_artifact_history.rpy:320x200|game/scenes/stage4/stage4_begin.rpy:320x200|game/scenes/stage4/stage4_decision.rpy:320x200|game/scenes/stage4/stage4_echo_desire.rpy:320x200|game/scenes/stage4/stage4_echo_effects.rpy:320x200|game/scenes/stage4/stage4_echo_liberation.rpy:320x200|game/scenes/stage4/stage4_garden_event.rpy:320x200|game/scenes/stage4/stage4_suspect_s.rpy:320x200|game/scenes/stage5/stage5_art_room_crisis.rpy:320x200|game/scenes/stage5/stage5_begin.rpy:320x200|game/scenes/stage5/stage5_computer_lab_crisis.rpy:320x200|game/scenes/stage5/stage5_emergency_meeting.rpy:320x200|game/scenes/stage5/stage5_gym_crisis.rpy:320x200|game/scenes/stage5/stage5_phenomenon.rpy:320x200|game/scenes/stage5/stage5_protect_path.rpy:320x200|game/scenes/stage5/stage5_pursue_path.rpy:320x200|game/scenes/stage6/stage6_begin.rpy:320x200|game/scenes/stage6/stage6_evidence_compiled.rpy:320x200|game/scenes/stage6/stage6_final_clue_library.rpy:320x200|game/scenes/stage6/stage6_final_clue_occult.rpy:320x200|game/scenes/stage6/stage6_final_clue_tech.rpy:320x200|game/scenes/stage6/stage6_preparation.rpy:320x200|game/scenes/stage6/stage6_solo_investigation.rpy:320x200|game/scenes/stage6/stage6_team_formation.rpy:320x200|game/scenes/stage6/stage6_team_strategy.rpy:320x200|game/scenes/stage7/stage7_aftermath.rpy:320x200|game/scenes/stage7/stage7_battle.rpy:320x200|game/scenes/stage7/stage7_begin.rpy:320x200|game/scenes/stage7/stage7_challenge_echo.rpy:320x200|game/scenes/stage7/stage7_help_echo.rpy:320x200|game/scenes/stage7/stage7_integration.rpy:320x200|game/scenes/stage7/stage7_negotiate_binding.rpy:320x200|game/scenes/stage7/stage7_ritual_self.rpy:320x200|game/scenes/stage7/stage7_ritual_shared.rpy:320x200|game/scenes/stage7/stage7_ritual_sterling.rpy:320x200|game/scenes/stage8/stage8_begin.rpy:320x200|game/scenes/stage8/stage8_ending_battle_defeat.rpy:320x200|game/scenes/stage8/stage8_ending_battle_victory.rpy:320x200|game/scenes/stage8/stage8_ending_bittersweet.rpy:320x200|game/scenes/stage8/stage8_ending_integration.rpy:320x200|game/scenes/stage8/stage8_ending_self_sacrifice.rpy:320x200|game/scenes/stage8/stage8_ending_shared_perfect.rpy:320x200|game/scenes/stage8/stage8_ending_sterling_sacrifice.rpy:320x200|game/scenes/stage8/stage8_epilogue_solo.rpy:320x200|game/scenes/stage8/stage8_epilogue_team.rpy:320x200|game/screens.rpy:320x200|game/script.rpy:320x200|game/variables.rpy:320x200;links=block-10-1776336033891->block-11-1776336033891:jump|block-10-1776336033891->block-7-1776336033891:jump|block-11-1776336033891->block-4-1776336033891:call|block-11-1776336033891->block-7-1776336033891:jump|block-11-1776336033891->block-8-1776336033891:jump|block-12-1776336033891->block-10-1776336033891:jump|block-12-1776336033891->block-5-1776336033891:jump|block-14-1776336033891->block-17-1776336033891:jump|block-14-1776336033891->block-18-1776336033891:jump|block-14-1776336033891->block-20-1776336033891:jump|block-14-1776336033891->block-22-1776336033891:jump|block-14-1776336033891->block-7-1776336033891:jump|block-15-1776336033891->block-23-1776336033891:jump|block-16-1776336033891->block-15-1776336033891:jump|block-17-1776336033891->block-16-1776336033891:jump|block-19-1776336033891->block-15-1776336033891:jump|block-20-1776336033891->block-19-1776336033891:jump|block-21-1776336033891->block-15-1776336033891:jump|block-22-1776336033891->block-21-1776336033891:jump|block-23-1776336033891->block-27-1776336033891:jump|block-23-1776336033891->block-28-1776336033891:jump|block-23-1776336033891->block-29-1776336033891:jump|block-23-1776336033891->block-30-1776336033891:jump|block-23-1776336033891->block-31-1776336033891:jump|block-24-1776336033891->block-34-1776336033891:jump|block-25-1776336033891->block-26-1776336033891:jump|block-26-1776336033891->block-24-1776336033891:jump|block-27-1776336033891->block-25-1776336033891:jump|block-28-1776336033891->block-25-1776336033891:jump|block-29-1776336033891->block-25-1776336033891:jump|block-30-1776336033891->block-25-1776336033891:jump|block-31-1776336033891->block-25-1776336033891:jump|block-32-1776336033891->block-24-1776336033891:jump|block-32-1776336033891->block-35-1776336033891:jump|block-33-1776336033891->block-39-1776336033891:jump|block-34-1776336033891->block-33-1776336033891:jump|block-35-1776336033891->block-42-1776336033891:jump|block-36-1776336033891->block-32-1776336033891:jump|block-37-1776336033891->block-32-1776336033891:jump|block-38-1776336033891->block-40-1776336033891:jump|block-39-1776336033891->block-36-1776336033891:jump|block-39-1776336033891->block-37-1776336033891:jump|block-39-1776336033891->block-38-1776336033891:jump|block-40-1776336033891->block-32-1776336033891:jump|block-41-1776336033891->block-44-1776336033891:jump|block-42-1776336033891->block-41-1776336033891:jump|block-42-1776336033891->block-43-1776336033891:jump|block-42-1776336033891->block-45-1776336033891:jump|block-43-1776336033891->block-44-1776336033891:jump|block-44-1776336033891->block-47-1776336033891:jump|block-44-1776336033891->block-48-1776336033891:jump|block-45-1776336033891->block-44-1776336033891:jump|block-46-1776336033891->block-44-1776336033891:jump|block-47-1776336033891->block-49-1776336033891:jump|block-48-1776336033891->block-49-1776336033891:jump|block-49-1776336033891->block-55-1776336033891:jump|block-49-1776336033891->block-56-1776336033891:jump|block-5-1776336033891->block-10-1776336033891:jump|block-5-1776336033891->block-11-1776336033891:jump|block-50-1776336033891->block-54-1776336033891:jump|block-51-1776336033891->block-50-1776336033891:jump|block-52-1776336033891->block-50-1776336033891:jump|block-53-1776336033891->block-50-1776336033891:jump|block-54-1776336033891->block-60-1776336033891:jump|block-55-1776336033891->block-51-1776336033891:jump|block-55-1776336033891->block-52-1776336033891:jump|block-55-1776336033891->block-53-1776336033891:jump|block-56-1776336033891->block-57-1776336033891:jump|block-57-1776336033891->block-50-1776336033891:jump|block-58-1776336033891->block-68-1776336033891:jump|block-59-1776336033891->block-58-1776336033891:jump|block-6-1776336033891->block-12-1776336033891:jump|block-6-1776336033891->block-5-1776336033891:jump|block-6-1776336033891->block-9-1776336033891:jump|block-60-1776336033891->block-61-1776336033891:jump|block-60-1776336033891->block-62-1776336033891:jump|block-60-1776336033891->block-64-1776336033891:jump|block-61-1776336033891->block-59-1776336033891:jump|block-61-1776336033891->block-62-1776336033891:jump|block-62-1776336033891->block-65-1776336033891:jump|block-62-1776336033891->block-66-1776336033891:jump|block-62-1776336033891->block-67-1776336033891:jump|block-63-1776336033891->block-58-1776336033891:jump|block-64-1776336033891->block-62-1776336033891:jump|block-64-1776336033891->block-63-1776336033891:jump|block-65-1776336033891->block-58-1776336033891:jump|block-66-1776336033891->block-58-1776336033891:jump|block-67-1776336033891->block-58-1776336033891:jump|block-68-1776336033891->block-69-1776336033891:jump|block-68-1776336033891->block-70-1776336033891:jump|block-68-1776336033891->block-71-1776336033891:jump|block-68-1776336033891->block-72-1776336033891:jump|block-68-1776336033891->block-73-1776336033891:jump|block-68-1776336033891->block-74-1776336033891:jump|block-68-1776336033891->block-75-1776336033891:jump|block-69-1776336033891->block-76-1776336033891:jump|block-7-1776336033891->block-8-1776336033891:jump|block-70-1776336033891->block-76-1776336033891:jump|block-71-1776336033891->block-77-1776336033891:jump|block-72-1776336033891->block-77-1776336033891:jump|block-73-1776336033891->block-76-1776336033891:jump|block-74-1776336033891->block-77-1776336033891:jump|block-75-1776336033891->block-77-1776336033891:jump|block-79-1776336033891->block-6-1776336033891:jump|block-8-1776336033891->block-13-1776336033891:call|block-8-1776336033891->block-14-1776336033891:jump|block-9-1776336033891->block-10-1776336033891:jump|block-9-1776336033891->block-11-1776336033891:jump",
-  "storyCanvasHasAutocentered": true,
-  "routeCanvasLayoutFingerprint": "v2;mode=flow-lr;group=none;nodes=block-10-1776336033891:stage1_meet_h:stage1_meet_h.rpy:180x40|block-11-1776336033891:stage1_meet_s:stage1_meet_s.rpy:180x40|block-12-1776336033891:stage1_rumors:stage1_rumors.rpy:180x40|block-13-1776336033891:TestScriptX:TestScript.rpy:180x40|block-14-1776336033891:stage2_begin:stage2_begin.rpy:180x40|block-15-1776336033891:stage2_converge:stage2_converge.rpy:180x40|block-16-1776336033891:stage2_library_clue:stage2_library_clue.rpy:180x40|block-17-1776336033891:stage2_library_path:stage2_library_path.rpy:180x40|block-18-1776336033891:stage2_occult_path:stage2_occult_path.rpy:180x40|block-19-1776336033891:stage2_social_clue:stage2_social_clue.rpy:180x40|block-20-1776336033891:stage2_interview_custodian:stage2_social_path.rpy:180x40|block-20-1776336033891:stage2_interview_sterling:stage2_social_path.rpy:180x40|block-20-1776336033891:stage2_interview_student:stage2_social_path.rpy:180x40|block-20-1776336033891:stage2_social_path:stage2_social_path.rpy:180x40|block-21-1776336033891:stage2_tech_clue:stage2_tech_clue.rpy:180x40|block-22-1776336033891:stage2_tech_path:stage2_tech_path.rpy:180x40|block-23-1776336033891:stage3_begin:stage3_begin.rpy:180x40|block-24-1776336033891:stage3_night:stage3_night.rpy:180x40|block-25-1776336033891:stage3_partnership:stage3_partnership.rpy:180x40|block-26-1776336033891:stage3_revelation:stage3_revelation.rpy:180x40|block-27-1776336033891:stage3_trust_h:stage3_trust_h.rpy:180x40|block-28-1776336033891:stage3_trust_k:stage3_trust_k.rpy:180x40|block-29-1776336033891:stage3_trust_l:stage3_trust_l.rpy:180x40|block-30-1776336033891:stage3_trust_m:stage3_trust_m.rpy:180x40|block-31-1776336033891:stage3_trust_y:stage3_trust_y.rpy:180x40|block-32-1776336033891:stage4_analyze_clues:stage4_analyze_clues.rpy:180x40|block-33-1776336033891:stage4_artifact_history:stage4_artifact_history.rpy:180x40|block-34-1776336033891:stage4_begin:stage4_begin.rpy:180x40|block-35-1776336033891:stage4_decision:stage4_decision.rpy:180x40|block-35-1776336033891:stage4_theory_binding:stage4_decision.rpy:180x40|block-35-1776336033891:stage4_theory_coexist:stage4_decision.rpy:180x40|block-35-1776336033891:stage4_theory_destroy:stage4_decision.rpy:180x40|block-35-1776336033891:stage4_theory_exit:stage4_decision.rpy:180x40|block-36-1776336033891:stage4_echo_desire:stage4_echo_desire.rpy:180x40|block-37-1776336033891:stage4_echo_effects:stage4_echo_effects.rpy:180x40|block-38-1776336033891:stage4_echo_liberation:stage4_echo_liberation.rpy:180x40|block-39-1776336033891:stage4_garden_event:stage4_garden_event.rpy:180x40|block-4-1776336033891:clarity_file_maxim:RopedCovenant.rpy:180x40|block-40-1776336033891:stage4_suspect_s:stage4_suspect_s.rpy:180x40|block-41-1776336033891:stage5_art_room_crisis:stage5_art_room_crisis.rpy:180x40|block-42-1776336033891:stage5_begin:stage5_begin.rpy:180x40|block-43-1776336033891:stage5_computer_lab_crisis:stage5_computer_lab_crisis.rpy:180x40|block-44-1776336033891:stage5_emergency_meeting:stage5_emergency_meeting.rpy:180x40|block-45-1776336033891:stage5_gym_crisis:stage5_gym_crisis.rpy:180x40|block-46-1776336033891:stage5_phenomenon:stage5_phenomenon.rpy:180x40|block-47-1776336033891:stage5_protect_path:stage5_protect_path.rpy:180x40|block-48-1776336033891:stage5_pursue_path:stage5_pursue_path.rpy:180x40|block-49-1776336033891:stage6_begin:stage6_begin.rpy:180x40|block-5-1776336033891:stage1_announcement:stage1_announcement.rpy:180x40|block-50-1776336033891:stage6_evidence_compiled:stage6_evidence_compiled.rpy:180x40|block-51-1776336033891:stage6_final_clue_library:stage6_final_clue_library.rpy:180x40|block-52-1776336033891:stage6_final_clue_occult:stage6_final_clue_occult.rpy:180x40|block-53-1776336033891:stage6_final_clue_tech:stage6_final_clue_tech.rpy:180x40|block-54-1776336033891:stage6_preparation:stage6_preparation.rpy:180x40|block-55-1776336033891:stage6_solo_investigation:stage6_solo_investigation.rpy:180x40|block-56-1776336033891:stage6_team_formation:stage6_team_formation.rpy:180x40|block-57-1776336033891:stage6_team_strategy:stage6_team_strategy.rpy:180x40|block-58-1776336033891:stage7_aftermath:stage7_aftermath.rpy:180x40|block-59-1776336033891:stage7_battle:stage7_battle.rpy:180x40|block-6-1776336033891:stage1_arrival:stage1_arrival.rpy:180x40|block-60-1776336033891:stage7_begin:stage7_begin.rpy:180x40|block-61-1776336033891:stage7_challenge_echo:stage7_challenge_echo.rpy:180x40|block-62-1776336033891:stage7_help_echo:stage7_help_echo.rpy:180x40|block-63-1776336033891:stage7_integration:stage7_integration.rpy:180x40|block-64-1776336033891:stage7_negotiate_binding:stage7_negotiate_binding.rpy:180x40|block-65-1776336033891:stage7_ritual_self:stage7_ritual_self.rpy:180x40|block-66-1776336033891:stage7_ritual_shared:stage7_ritual_shared.rpy:180x40|block-67-1776336033891:stage7_ritual_sterling:stage7_ritual_sterling.rpy:180x40|block-68-1776336033891:stage8_begin:stage8_begin.rpy:180x40|block-69-1776336033891:stage8_ending_battle_defeat:stage8_ending_battle_defeat.rpy:180x40|block-7-1776336033891:stage1_choice:stage1_choice.rpy:180x40|block-70-1776336033891:stage8_ending_battle_victory:stage8_ending_battle_victory.rpy:180x40|block-71-1776336033891:stage8_ending_bittersweet:stage8_ending_bittersweet.rpy:180x40|block-72-1776336033891:stage8_ending_integration:stage8_ending_integration.rpy:180x40|block-73-1776336033891:stage8_ending_self_sacrifice:stage8_ending_self_sacrifice.rpy:180x40|block-74-1776336033891:stage8_ending_shared_perfect:stage8_ending_shared_perfect.rpy:180x40|block-75-1776336033891:stage8_ending_sterling_sacrifice:stage8_ending_sterling_sacrifice.rpy:180x40|block-76-1776336033891:stage8_epilogue_solo:stage8_epilogue_solo.rpy:180x40|block-77-1776336033891:stage8_epilogue_team:stage8_epilogue_team.rpy:180x40|block-79-1776336033891:start:script.rpy:180x40|block-8-1776336033891:stage1_evening:stage1_evening.rpy:180x40|block-9-1776336033891:stage1_library_notice:stage1_library_notice.rpy:180x40;edges=block-10-1776336033891:stage1_meet_h->block-11-1776336033891:stage1_meet_s:jump|block-10-1776336033891:stage1_meet_h->block-7-1776336033891:stage1_choice:jump|block-11-1776336033891:stage1_meet_s->block-4-1776336033891:clarity_file_maxim:call|block-11-1776336033891:stage1_meet_s->block-7-1776336033891:stage1_choice:jump|block-11-1776336033891:stage1_meet_s->block-8-1776336033891:stage1_evening:jump|block-12-1776336033891:stage1_rumors->block-10-1776336033891:stage1_meet_h:jump|block-12-1776336033891:stage1_rumors->block-5-1776336033891:stage1_announcement:jump|block-14-1776336033891:stage2_begin->block-17-1776336033891:stage2_library_path:jump|block-14-1776336033891:stage2_begin->block-18-1776336033891:stage2_occult_path:jump|block-14-1776336033891:stage2_begin->block-20-1776336033891:stage2_social_path:jump|block-14-1776336033891:stage2_begin->block-22-1776336033891:stage2_tech_path:jump|block-14-1776336033891:stage2_begin->block-7-1776336033891:stage1_choice:jump|block-15-1776336033891:stage2_converge->block-23-1776336033891:stage3_begin:jump|block-16-1776336033891:stage2_library_clue->block-15-1776336033891:stage2_converge:jump|block-17-1776336033891:stage2_library_path->block-16-1776336033891:stage2_library_clue:jump|block-19-1776336033891:stage2_social_clue->block-15-1776336033891:stage2_converge:jump|block-20-1776336033891:stage2_interview_custodian->block-19-1776336033891:stage2_social_clue:jump|block-20-1776336033891:stage2_interview_sterling->block-19-1776336033891:stage2_social_clue:jump|block-20-1776336033891:stage2_interview_student->block-19-1776336033891:stage2_social_clue:jump|block-20-1776336033891:stage2_social_path->block-20-1776336033891:stage2_interview_custodian:jump|block-20-1776336033891:stage2_social_path->block-20-1776336033891:stage2_interview_sterling:implicit|block-20-1776336033891:stage2_social_path->block-20-1776336033891:stage2_interview_sterling:jump|block-20-1776336033891:stage2_social_path->block-20-1776336033891:stage2_interview_student:jump|block-21-1776336033891:stage2_tech_clue->block-15-1776336033891:stage2_converge:jump|block-22-1776336033891:stage2_tech_path->block-21-1776336033891:stage2_tech_clue:jump|block-23-1776336033891:stage3_begin->block-27-1776336033891:stage3_trust_h:jump|block-23-1776336033891:stage3_begin->block-28-1776336033891:stage3_trust_k:jump|block-23-1776336033891:stage3_begin->block-29-1776336033891:stage3_trust_l:jump|block-23-1776336033891:stage3_begin->block-30-1776336033891:stage3_trust_m:jump|block-23-1776336033891:stage3_begin->block-31-1776336033891:stage3_trust_y:jump|block-24-1776336033891:stage3_night->block-34-1776336033891:stage4_begin:jump|block-25-1776336033891:stage3_partnership->block-26-1776336033891:stage3_revelation:jump|block-26-1776336033891:stage3_revelation->block-24-1776336033891:stage3_night:jump|block-27-1776336033891:stage3_trust_h->block-25-1776336033891:stage3_partnership:jump|block-28-1776336033891:stage3_trust_k->block-25-1776336033891:stage3_partnership:jump|block-29-1776336033891:stage3_trust_l->block-25-1776336033891:stage3_partnership:jump|block-30-1776336033891:stage3_trust_m->block-25-1776336033891:stage3_partnership:jump|block-31-1776336033891:stage3_trust_y->block-25-1776336033891:stage3_partnership:jump|block-32-1776336033891:stage4_analyze_clues->block-24-1776336033891:stage3_night:jump|block-32-1776336033891:stage4_analyze_clues->block-35-1776336033891:stage4_theory_binding:jump|block-32-1776336033891:stage4_analyze_clues->block-35-1776336033891:stage4_theory_coexist:jump|block-32-1776336033891:stage4_analyze_clues->block-35-1776336033891:stage4_theory_destroy:jump|block-32-1776336033891:stage4_analyze_clues->block-35-1776336033891:stage4_theory_exit:jump|block-33-1776336033891:stage4_artifact_history->block-39-1776336033891:stage4_garden_event:jump|block-34-1776336033891:stage4_begin->block-33-1776336033891:stage4_artifact_history:jump|block-35-1776336033891:stage4_decision->block-42-1776336033891:stage5_begin:jump|block-35-1776336033891:stage4_theory_binding->block-35-1776336033891:stage4_decision:jump|block-35-1776336033891:stage4_theory_coexist->block-35-1776336033891:stage4_decision:jump|block-35-1776336033891:stage4_theory_destroy->block-35-1776336033891:stage4_decision:jump|block-35-1776336033891:stage4_theory_exit->block-35-1776336033891:stage4_decision:jump|block-36-1776336033891:stage4_echo_desire->block-32-1776336033891:stage4_analyze_clues:jump|block-37-1776336033891:stage4_echo_effects->block-32-1776336033891:stage4_analyze_clues:jump|block-38-1776336033891:stage4_echo_liberation->block-40-1776336033891:stage4_suspect_s:jump|block-39-1776336033891:stage4_garden_event->block-36-1776336033891:stage4_echo_desire:jump|block-39-1776336033891:stage4_garden_event->block-37-1776336033891:stage4_echo_effects:jump|block-39-1776336033891:stage4_garden_event->block-38-1776336033891:stage4_echo_liberation:jump|block-40-1776336033891:stage4_suspect_s->block-32-1776336033891:stage4_analyze_clues:jump|block-41-1776336033891:stage5_art_room_crisis->block-44-1776336033891:stage5_emergency_meeting:jump|block-42-1776336033891:stage5_begin->block-41-1776336033891:stage5_art_room_crisis:jump|block-42-1776336033891:stage5_begin->block-43-1776336033891:stage5_computer_lab_crisis:jump|block-42-1776336033891:stage5_begin->block-45-1776336033891:stage5_gym_crisis:jump|block-43-1776336033891:stage5_computer_lab_crisis->block-44-1776336033891:stage5_emergency_meeting:jump|block-44-1776336033891:stage5_emergency_meeting->block-47-1776336033891:stage5_protect_path:jump|block-44-1776336033891:stage5_emergency_meeting->block-48-1776336033891:stage5_pursue_path:jump|block-45-1776336033891:stage5_gym_crisis->block-44-1776336033891:stage5_emergency_meeting:jump|block-46-1776336033891:stage5_phenomenon->block-44-1776336033891:stage5_emergency_meeting:jump|block-47-1776336033891:stage5_protect_path->block-49-1776336033891:stage6_begin:jump|block-48-1776336033891:stage5_pursue_path->block-49-1776336033891:stage6_begin:jump|block-49-1776336033891:stage6_begin->block-55-1776336033891:stage6_solo_investigation:jump|block-49-1776336033891:stage6_begin->block-56-1776336033891:stage6_team_formation:jump|block-5-1776336033891:stage1_announcement->block-10-1776336033891:stage1_meet_h:jump|block-5-1776336033891:stage1_announcement->block-11-1776336033891:stage1_meet_s:jump|block-50-1776336033891:stage6_evidence_compiled->block-54-1776336033891:stage6_preparation:jump|block-51-1776336033891:stage6_final_clue_library->block-50-1776336033891:stage6_evidence_compiled:jump|block-52-1776336033891:stage6_final_clue_occult->block-50-1776336033891:stage6_evidence_compiled:jump|block-53-1776336033891:stage6_final_clue_tech->block-50-1776336033891:stage6_evidence_compiled:jump|block-54-1776336033891:stage6_preparation->block-60-1776336033891:stage7_begin:jump|block-55-1776336033891:stage6_solo_investigation->block-51-1776336033891:stage6_final_clue_library:jump|block-55-1776336033891:stage6_solo_investigation->block-52-1776336033891:stage6_final_clue_occult:jump|block-55-1776336033891:stage6_solo_investigation->block-53-1776336033891:stage6_final_clue_tech:jump|block-56-1776336033891:stage6_team_formation->block-57-1776336033891:stage6_team_strategy:jump|block-57-1776336033891:stage6_team_strategy->block-50-1776336033891:stage6_evidence_compiled:jump|block-58-1776336033891:stage7_aftermath->block-68-1776336033891:stage8_begin:jump|block-59-1776336033891:stage7_battle->block-58-1776336033891:stage7_aftermath:jump|block-6-1776336033891:stage1_arrival->block-12-1776336033891:stage1_rumors:jump|block-6-1776336033891:stage1_arrival->block-5-1776336033891:stage1_announcement:jump|block-6-1776336033891:stage1_arrival->block-9-1776336033891:stage1_library_notice:jump|block-60-1776336033891:stage7_begin->block-61-1776336033891:stage7_challenge_echo:jump|block-60-1776336033891:stage7_begin->block-62-1776336033891:stage7_help_echo:jump|block-60-1776336033891:stage7_begin->block-64-1776336033891:stage7_negotiate_binding:jump|block-61-1776336033891:stage7_challenge_echo->block-59-1776336033891:stage7_battle:jump|block-61-1776336033891:stage7_challenge_echo->block-62-1776336033891:stage7_help_echo:jump|block-62-1776336033891:stage7_help_echo->block-65-1776336033891:stage7_ritual_self:jump|block-62-1776336033891:stage7_help_echo->block-65-1776336033891:stage7_ritual_self:jump|block-62-1776336033891:stage7_help_echo->block-66-1776336033891:stage7_ritual_shared:jump|block-62-1776336033891:stage7_help_echo->block-67-1776336033891:stage7_ritual_sterling:jump|block-63-1776336033891:stage7_integration->block-58-1776336033891:stage7_aftermath:jump|block-64-1776336033891:stage7_negotiate_binding->block-62-1776336033891:stage7_help_echo:jump|block-64-1776336033891:stage7_negotiate_binding->block-63-1776336033891:stage7_integration:jump|block-65-1776336033891:stage7_ritual_self->block-58-1776336033891:stage7_aftermath:jump|block-66-1776336033891:stage7_ritual_shared->block-58-1776336033891:stage7_aftermath:jump|block-67-1776336033891:stage7_ritual_sterling->block-58-1776336033891:stage7_aftermath:jump|block-68-1776336033891:stage8_begin->block-69-1776336033891:stage8_ending_battle_defeat:jump|block-68-1776336033891:stage8_begin->block-70-1776336033891:stage8_ending_battle_victory:jump|block-68-1776336033891:stage8_begin->block-71-1776336033891:stage8_ending_bittersweet:jump|block-68-1776336033891:stage8_begin->block-72-1776336033891:stage8_ending_integration:jump|block-68-1776336033891:stage8_begin->block-73-1776336033891:stage8_ending_self_sacrifice:jump|block-68-1776336033891:stage8_begin->block-74-1776336033891:stage8_ending_shared_perfect:jump|block-68-1776336033891:stage8_begin->block-75-1776336033891:stage8_ending_sterling_sacrifice:jump|block-69-1776336033891:stage8_ending_battle_defeat->block-76-1776336033891:stage8_epilogue_solo:jump|block-7-1776336033891:stage1_choice->block-8-1776336033891:stage1_evening:jump|block-7-1776336033891:stage1_choice->block-8-1776336033891:stage1_evening:jump|block-7-1776336033891:stage1_choice->block-8-1776336033891:stage1_evening:jump|block-7-1776336033891:stage1_choice->block-8-1776336033891:stage1_evening:jump|block-70-1776336033891:stage8_ending_battle_victory->block-76-1776336033891:stage8_epilogue_solo:jump|block-71-1776336033891:stage8_ending_bittersweet->block-77-1776336033891:stage8_epilogue_team:jump|block-72-1776336033891:stage8_ending_integration->block-77-1776336033891:stage8_epilogue_team:jump|block-73-1776336033891:stage8_ending_self_sacrifice->block-76-1776336033891:stage8_epilogue_solo:jump|block-74-1776336033891:stage8_ending_shared_perfect->block-77-1776336033891:stage8_epilogue_team:jump|block-75-1776336033891:stage8_ending_sterling_sacrifice->block-77-1776336033891:stage8_epilogue_team:jump|block-79-1776336033891:start->block-6-1776336033891:stage1_arrival:jump|block-8-1776336033891:stage1_evening->block-13-1776336033891:TestScriptX:call|block-8-1776336033891:stage1_evening->block-14-1776336033891:stage2_begin:jump|block-9-1776336033891:stage1_library_notice->block-10-1776336033891:stage1_meet_h:jump|block-9-1776336033891:stage1_library_notice->block-11-1776336033891:stage1_meet_s:jump",
-  "routeCanvasHasAutocentered": true,
-  "choiceCanvasHasAutocentered": true,
+  "storyCanvasLayoutFingerprint": "v2;mode=flow-lr;group=none;blocks=game/characters.rpy:320x200|game/debug_placeholders.rpy:320x200|game/gui.rpy:320x200|game/options.rpy:320x200|game/scenes/RopedCovenant.rpy:320x200|game/scenes/stage1/TestScript.rpy:320x200|game/scenes/stage1/stage1_announcement.rpy:320x200|game/scenes/stage1/stage1_arrival.rpy:320x200|game/scenes/stage1/stage1_choice.rpy:320x200|game/scenes/stage1/stage1_evening.rpy:320x200|game/scenes/stage1/stage1_library_notice.rpy:320x200|game/scenes/stage1/stage1_meet_h.rpy:320x200|game/scenes/stage1/stage1_meet_s.rpy:320x200|game/scenes/stage1/stage1_rumors.rpy:320x200|game/scenes/stage2/stage2_begin.rpy:320x200|game/scenes/stage2/stage2_converge.rpy:320x200|game/scenes/stage2/stage2_library_clue.rpy:320x200|game/scenes/stage2/stage2_library_path.rpy:320x200|game/scenes/stage2/stage2_occult_path.rpy:320x200|game/scenes/stage2/stage2_social_clue.rpy:320x200|game/scenes/stage2/stage2_social_path.rpy:320x200|game/scenes/stage2/stage2_tech_clue.rpy:320x200|game/scenes/stage2/stage2_tech_path.rpy:320x200|game/scenes/stage3/stage3_begin.rpy:320x200|game/scenes/stage3/stage3_night.rpy:320x200|game/scenes/stage3/stage3_partnership.rpy:320x200|game/scenes/stage3/stage3_revelation.rpy:320x200|game/scenes/stage3/stage3_trust_h.rpy:320x200|game/scenes/stage3/stage3_trust_k.rpy:320x200|game/scenes/stage3/stage3_trust_l.rpy:320x200|game/scenes/stage3/stage3_trust_m.rpy:320x200|game/scenes/stage3/stage3_trust_y.rpy:320x200|game/scenes/stage4/stage4_analyze_clues.rpy:320x200|game/scenes/stage4/stage4_artifact_history.rpy:320x200|game/scenes/stage4/stage4_begin.rpy:320x200|game/scenes/stage4/stage4_decision.rpy:320x200|game/scenes/stage4/stage4_echo_desire.rpy:320x200|game/scenes/stage4/stage4_echo_effects.rpy:320x200|game/scenes/stage4/stage4_echo_liberation.rpy:320x200|game/scenes/stage4/stage4_garden_event.rpy:320x200|game/scenes/stage4/stage4_suspect_s.rpy:320x200|game/scenes/stage5/stage5_art_room_crisis.rpy:320x200|game/scenes/stage5/stage5_begin.rpy:320x200|game/scenes/stage5/stage5_computer_lab_crisis.rpy:320x200|game/scenes/stage5/stage5_emergency_meeting.rpy:320x200|game/scenes/stage5/stage5_gym_crisis.rpy:320x200|game/scenes/stage5/stage5_phenomenon.rpy:320x200|game/scenes/stage5/stage5_protect_path.rpy:320x200|game/scenes/stage5/stage5_pursue_path.rpy:320x200|game/scenes/stage6/stage6_begin.rpy:320x200|game/scenes/stage6/stage6_evidence_compiled.rpy:320x200|game/scenes/stage6/stage6_final_clue_library.rpy:320x200|game/scenes/stage6/stage6_final_clue_occult.rpy:320x200|game/scenes/stage6/stage6_final_clue_tech.rpy:320x200|game/scenes/stage6/stage6_preparation.rpy:320x200|game/scenes/stage6/stage6_solo_investigation.rpy:320x200|game/scenes/stage6/stage6_team_formation.rpy:320x200|game/scenes/stage6/stage6_team_strategy.rpy:320x200|game/scenes/stage7/stage7_aftermath.rpy:320x200|game/scenes/stage7/stage7_battle.rpy:320x200|game/scenes/stage7/stage7_begin.rpy:320x200|game/scenes/stage7/stage7_challenge_echo.rpy:320x200|game/scenes/stage7/stage7_help_echo.rpy:320x200|game/scenes/stage7/stage7_integration.rpy:320x200|game/scenes/stage7/stage7_negotiate_binding.rpy:320x200|game/scenes/stage7/stage7_ritual_self.rpy:320x200|game/scenes/stage7/stage7_ritual_shared.rpy:320x200|game/scenes/stage7/stage7_ritual_sterling.rpy:320x200|game/scenes/stage8/stage8_begin.rpy:320x200|game/scenes/stage8/stage8_ending_battle_defeat.rpy:320x200|game/scenes/stage8/stage8_ending_battle_victory.rpy:320x200|game/scenes/stage8/stage8_ending_bittersweet.rpy:320x200|game/scenes/stage8/stage8_ending_integration.rpy:320x200|game/scenes/stage8/stage8_ending_self_sacrifice.rpy:320x200|game/scenes/stage8/stage8_ending_shared_perfect.rpy:320x200|game/scenes/stage8/stage8_ending_sterling_sacrifice.rpy:320x200|game/scenes/stage8/stage8_epilogue_solo.rpy:320x200|game/scenes/stage8/stage8_epilogue_team.rpy:320x200|game/screens.rpy:320x200|game/script.rpy:320x200|game/variables.rpy:320x200;links=block-10-1776472411519->block-11-1776472411519:jump|block-10-1776472411519->block-12-1776472411519:jump|block-11-1776472411519->block-12-1776472411519:jump|block-11-1776472411519->block-8-1776472411519:jump|block-12-1776472411519->block-4-1776472411519:call|block-12-1776472411519->block-8-1776472411519:jump|block-12-1776472411519->block-9-1776472411519:jump|block-13-1776472411519->block-11-1776472411519:jump|block-13-1776472411519->block-6-1776472411519:jump|block-14-1776472411519->block-17-1776472411519:jump|block-14-1776472411519->block-18-1776472411519:jump|block-14-1776472411519->block-20-1776472411519:jump|block-14-1776472411519->block-22-1776472411519:jump|block-14-1776472411519->block-8-1776472411519:jump|block-15-1776472411519->block-23-1776472411519:jump|block-16-1776472411519->block-15-1776472411519:jump|block-17-1776472411519->block-16-1776472411519:jump|block-19-1776472411519->block-15-1776472411519:jump|block-20-1776472411519->block-19-1776472411519:jump|block-21-1776472411519->block-15-1776472411519:jump|block-22-1776472411519->block-21-1776472411519:jump|block-23-1776472411519->block-27-1776472411519:jump|block-23-1776472411519->block-28-1776472411519:jump|block-23-1776472411519->block-29-1776472411519:jump|block-23-1776472411519->block-30-1776472411519:jump|block-23-1776472411519->block-31-1776472411519:jump|block-24-1776472411519->block-34-1776472411519:jump|block-25-1776472411519->block-26-1776472411519:jump|block-26-1776472411519->block-24-1776472411519:jump|block-27-1776472411519->block-25-1776472411519:jump|block-28-1776472411519->block-25-1776472411519:jump|block-29-1776472411519->block-25-1776472411519:jump|block-30-1776472411519->block-25-1776472411519:jump|block-31-1776472411519->block-25-1776472411519:jump|block-32-1776472411519->block-24-1776472411519:jump|block-32-1776472411519->block-35-1776472411519:jump|block-33-1776472411519->block-39-1776472411519:jump|block-34-1776472411519->block-33-1776472411519:jump|block-35-1776472411519->block-42-1776472411519:jump|block-36-1776472411519->block-32-1776472411519:jump|block-37-1776472411519->block-32-1776472411519:jump|block-38-1776472411519->block-40-1776472411519:jump|block-39-1776472411519->block-36-1776472411519:jump|block-39-1776472411519->block-37-1776472411519:jump|block-39-1776472411519->block-38-1776472411519:jump|block-40-1776472411519->block-32-1776472411519:jump|block-41-1776472411519->block-44-1776472411519:jump|block-42-1776472411519->block-41-1776472411519:jump|block-42-1776472411519->block-43-1776472411519:jump|block-42-1776472411519->block-45-1776472411519:jump|block-43-1776472411519->block-44-1776472411519:jump|block-44-1776472411519->block-47-1776472411519:jump|block-44-1776472411519->block-48-1776472411519:jump|block-45-1776472411519->block-44-1776472411519:jump|block-46-1776472411519->block-44-1776472411519:jump|block-47-1776472411519->block-49-1776472411519:jump|block-48-1776472411519->block-49-1776472411519:jump|block-49-1776472411519->block-55-1776472411519:jump|block-49-1776472411519->block-56-1776472411519:jump|block-50-1776472411519->block-54-1776472411519:jump|block-51-1776472411519->block-50-1776472411519:jump|block-52-1776472411519->block-50-1776472411519:jump|block-53-1776472411519->block-50-1776472411519:jump|block-54-1776472411519->block-60-1776472411519:jump|block-55-1776472411519->block-51-1776472411519:jump|block-55-1776472411519->block-52-1776472411519:jump|block-55-1776472411519->block-53-1776472411519:jump|block-56-1776472411519->block-57-1776472411519:jump|block-57-1776472411519->block-50-1776472411519:jump|block-58-1776472411519->block-68-1776472411519:jump|block-59-1776472411519->block-58-1776472411519:jump|block-6-1776472411519->block-11-1776472411519:jump|block-6-1776472411519->block-12-1776472411519:jump|block-60-1776472411519->block-61-1776472411519:jump|block-60-1776472411519->block-62-1776472411519:jump|block-60-1776472411519->block-64-1776472411519:jump|block-61-1776472411519->block-59-1776472411519:jump|block-61-1776472411519->block-62-1776472411519:jump|block-62-1776472411519->block-65-1776472411519:jump|block-62-1776472411519->block-66-1776472411519:jump|block-62-1776472411519->block-67-1776472411519:jump|block-63-1776472411519->block-58-1776472411519:jump|block-64-1776472411519->block-62-1776472411519:jump|block-64-1776472411519->block-63-1776472411519:jump|block-65-1776472411519->block-58-1776472411519:jump|block-66-1776472411519->block-58-1776472411519:jump|block-67-1776472411519->block-58-1776472411519:jump|block-68-1776472411519->block-69-1776472411519:jump|block-68-1776472411519->block-70-1776472411519:jump|block-68-1776472411519->block-71-1776472411519:jump|block-68-1776472411519->block-72-1776472411519:jump|block-68-1776472411519->block-73-1776472411519:jump|block-68-1776472411519->block-74-1776472411519:jump|block-68-1776472411519->block-75-1776472411519:jump|block-69-1776472411519->block-76-1776472411519:jump|block-7-1776472411519->block-10-1776472411519:jump|block-7-1776472411519->block-13-1776472411519:jump|block-7-1776472411519->block-6-1776472411519:jump|block-70-1776472411519->block-76-1776472411519:jump|block-71-1776472411519->block-77-1776472411519:jump|block-72-1776472411519->block-77-1776472411519:jump|block-73-1776472411519->block-76-1776472411519:jump|block-74-1776472411519->block-77-1776472411519:jump|block-75-1776472411519->block-77-1776472411519:jump|block-79-1776472411519->block-7-1776472411519:jump|block-8-1776472411519->block-9-1776472411519:jump|block-9-1776472411519->block-14-1776472411519:jump|block-9-1776472411519->block-5-1776472411519:call",
+  "storyCanvasHasAutocentered": false,
+  "routeCanvasLayoutFingerprint": "v2;mode=flow-lr;group=none;nodes=block-10-1776472411519:stage1_library_notice:stage1_library_notice.rpy:180x40|block-11-1776472411519:stage1_meet_h:stage1_meet_h.rpy:180x40|block-12-1776472411519:stage1_meet_s:stage1_meet_s.rpy:180x40|block-13-1776472411519:stage1_rumors:stage1_rumors.rpy:180x40|block-14-1776472411519:stage2_begin:stage2_begin.rpy:180x40|block-15-1776472411519:stage2_converge:stage2_converge.rpy:180x40|block-16-1776472411519:stage2_library_clue:stage2_library_clue.rpy:180x40|block-17-1776472411519:stage2_library_path:stage2_library_path.rpy:180x40|block-18-1776472411519:stage2_occult_path:stage2_occult_path.rpy:180x40|block-19-1776472411519:stage2_social_clue:stage2_social_clue.rpy:180x40|block-20-1776472411519:stage2_interview_custodian:stage2_social_path.rpy:180x40|block-20-1776472411519:stage2_interview_sterling:stage2_social_path.rpy:180x40|block-20-1776472411519:stage2_interview_student:stage2_social_path.rpy:180x40|block-20-1776472411519:stage2_social_path:stage2_social_path.rpy:180x40|block-21-1776472411519:stage2_tech_clue:stage2_tech_clue.rpy:180x40|block-22-1776472411519:stage2_tech_path:stage2_tech_path.rpy:180x40|block-23-1776472411519:stage3_begin:stage3_begin.rpy:180x40|block-24-1776472411519:stage3_night:stage3_night.rpy:180x40|block-25-1776472411519:stage3_partnership:stage3_partnership.rpy:180x40|block-26-1776472411519:stage3_revelation:stage3_revelation.rpy:180x40|block-27-1776472411519:stage3_trust_h:stage3_trust_h.rpy:180x40|block-28-1776472411519:stage3_trust_k:stage3_trust_k.rpy:180x40|block-29-1776472411519:stage3_trust_l:stage3_trust_l.rpy:180x40|block-30-1776472411519:stage3_trust_m:stage3_trust_m.rpy:180x40|block-31-1776472411519:stage3_trust_y:stage3_trust_y.rpy:180x40|block-32-1776472411519:stage4_analyze_clues:stage4_analyze_clues.rpy:180x40|block-33-1776472411519:stage4_artifact_history:stage4_artifact_history.rpy:180x40|block-34-1776472411519:stage4_begin:stage4_begin.rpy:180x40|block-35-1776472411519:stage4_decision:stage4_decision.rpy:180x40|block-35-1776472411519:stage4_theory_binding:stage4_decision.rpy:180x40|block-35-1776472411519:stage4_theory_coexist:stage4_decision.rpy:180x40|block-35-1776472411519:stage4_theory_destroy:stage4_decision.rpy:180x40|block-35-1776472411519:stage4_theory_exit:stage4_decision.rpy:180x40|block-36-1776472411519:stage4_echo_desire:stage4_echo_desire.rpy:180x40|block-37-1776472411519:stage4_echo_effects:stage4_echo_effects.rpy:180x40|block-38-1776472411519:stage4_echo_liberation:stage4_echo_liberation.rpy:180x40|block-39-1776472411519:stage4_garden_event:stage4_garden_event.rpy:180x40|block-4-1776472411519:clarity_file_maxim:RopedCovenant.rpy:180x40|block-40-1776472411519:stage4_suspect_s:stage4_suspect_s.rpy:180x40|block-41-1776472411519:stage5_art_room_crisis:stage5_art_room_crisis.rpy:180x40|block-42-1776472411519:stage5_begin:stage5_begin.rpy:180x40|block-43-1776472411519:stage5_computer_lab_crisis:stage5_computer_lab_crisis.rpy:180x40|block-44-1776472411519:stage5_emergency_meeting:stage5_emergency_meeting.rpy:180x40|block-45-1776472411519:stage5_gym_crisis:stage5_gym_crisis.rpy:180x40|block-46-1776472411519:stage5_phenomenon:stage5_phenomenon.rpy:180x40|block-47-1776472411519:stage5_protect_path:stage5_protect_path.rpy:180x40|block-48-1776472411519:stage5_pursue_path:stage5_pursue_path.rpy:180x40|block-49-1776472411519:stage6_begin:stage6_begin.rpy:180x40|block-5-1776472411519:TestScriptX:TestScript.rpy:180x40|block-50-1776472411519:stage6_evidence_compiled:stage6_evidence_compiled.rpy:180x40|block-51-1776472411519:stage6_final_clue_library:stage6_final_clue_library.rpy:180x40|block-52-1776472411519:stage6_final_clue_occult:stage6_final_clue_occult.rpy:180x40|block-53-1776472411519:stage6_final_clue_tech:stage6_final_clue_tech.rpy:180x40|block-54-1776472411519:stage6_preparation:stage6_preparation.rpy:180x40|block-55-1776472411519:stage6_solo_investigation:stage6_solo_investigation.rpy:180x40|block-56-1776472411519:stage6_team_formation:stage6_team_formation.rpy:180x40|block-57-1776472411519:stage6_team_strategy:stage6_team_strategy.rpy:180x40|block-58-1776472411519:stage7_aftermath:stage7_aftermath.rpy:180x40|block-59-1776472411519:stage7_battle:stage7_battle.rpy:180x40|block-6-1776472411519:stage1_announcement:stage1_announcement.rpy:180x40|block-60-1776472411519:stage7_begin:stage7_begin.rpy:180x40|block-61-1776472411519:stage7_challenge_echo:stage7_challenge_echo.rpy:180x40|block-62-1776472411519:stage7_help_echo:stage7_help_echo.rpy:180x40|block-63-1776472411519:stage7_integration:stage7_integration.rpy:180x40|block-64-1776472411519:stage7_negotiate_binding:stage7_negotiate_binding.rpy:180x40|block-65-1776472411519:stage7_ritual_self:stage7_ritual_self.rpy:180x40|block-66-1776472411519:stage7_ritual_shared:stage7_ritual_shared.rpy:180x40|block-67-1776472411519:stage7_ritual_sterling:stage7_ritual_sterling.rpy:180x40|block-68-1776472411519:stage8_begin:stage8_begin.rpy:180x40|block-69-1776472411519:stage8_ending_battle_defeat:stage8_ending_battle_defeat.rpy:180x40|block-7-1776472411519:stage1_arrival:stage1_arrival.rpy:180x40|block-70-1776472411519:stage8_ending_battle_victory:stage8_ending_battle_victory.rpy:180x40|block-71-1776472411519:stage8_ending_bittersweet:stage8_ending_bittersweet.rpy:180x40|block-72-1776472411519:stage8_ending_integration:stage8_ending_integration.rpy:180x40|block-73-1776472411519:stage8_ending_self_sacrifice:stage8_ending_self_sacrifice.rpy:180x40|block-74-1776472411519:stage8_ending_shared_perfect:stage8_ending_shared_perfect.rpy:180x40|block-75-1776472411519:stage8_ending_sterling_sacrifice:stage8_ending_sterling_sacrifice.rpy:180x40|block-76-1776472411519:stage8_epilogue_solo:stage8_epilogue_solo.rpy:180x40|block-77-1776472411519:stage8_epilogue_team:stage8_epilogue_team.rpy:180x40|block-79-1776472411519:start:script.rpy:180x40|block-8-1776472411519:stage1_choice:stage1_choice.rpy:180x40|block-9-1776472411519:stage1_evening:stage1_evening.rpy:180x40;edges=block-10-1776472411519:stage1_library_notice->block-11-1776472411519:stage1_meet_h:jump|block-10-1776472411519:stage1_library_notice->block-12-1776472411519:stage1_meet_s:jump|block-11-1776472411519:stage1_meet_h->block-12-1776472411519:stage1_meet_s:jump|block-11-1776472411519:stage1_meet_h->block-8-1776472411519:stage1_choice:jump|block-12-1776472411519:stage1_meet_s->block-4-1776472411519:clarity_file_maxim:call|block-12-1776472411519:stage1_meet_s->block-8-1776472411519:stage1_choice:jump|block-12-1776472411519:stage1_meet_s->block-9-1776472411519:stage1_evening:jump|block-13-1776472411519:stage1_rumors->block-11-1776472411519:stage1_meet_h:jump|block-13-1776472411519:stage1_rumors->block-6-1776472411519:stage1_announcement:jump|block-14-1776472411519:stage2_begin->block-17-1776472411519:stage2_library_path:jump|block-14-1776472411519:stage2_begin->block-18-1776472411519:stage2_occult_path:jump|block-14-1776472411519:stage2_begin->block-20-1776472411519:stage2_social_path:jump|block-14-1776472411519:stage2_begin->block-22-1776472411519:stage2_tech_path:jump|block-14-1776472411519:stage2_begin->block-8-1776472411519:stage1_choice:jump|block-15-1776472411519:stage2_converge->block-23-1776472411519:stage3_begin:jump|block-16-1776472411519:stage2_library_clue->block-15-1776472411519:stage2_converge:jump|block-17-1776472411519:stage2_library_path->block-16-1776472411519:stage2_library_clue:jump|block-19-1776472411519:stage2_social_clue->block-15-1776472411519:stage2_converge:jump|block-20-1776472411519:stage2_interview_custodian->block-19-1776472411519:stage2_social_clue:jump|block-20-1776472411519:stage2_interview_sterling->block-19-1776472411519:stage2_social_clue:jump|block-20-1776472411519:stage2_interview_student->block-19-1776472411519:stage2_social_clue:jump|block-20-1776472411519:stage2_social_path->block-20-1776472411519:stage2_interview_custodian:jump|block-20-1776472411519:stage2_social_path->block-20-1776472411519:stage2_interview_sterling:implicit|block-20-1776472411519:stage2_social_path->block-20-1776472411519:stage2_interview_sterling:jump|block-20-1776472411519:stage2_social_path->block-20-1776472411519:stage2_interview_student:jump|block-21-1776472411519:stage2_tech_clue->block-15-1776472411519:stage2_converge:jump|block-22-1776472411519:stage2_tech_path->block-21-1776472411519:stage2_tech_clue:jump|block-23-1776472411519:stage3_begin->block-27-1776472411519:stage3_trust_h:jump|block-23-1776472411519:stage3_begin->block-28-1776472411519:stage3_trust_k:jump|block-23-1776472411519:stage3_begin->block-29-1776472411519:stage3_trust_l:jump|block-23-1776472411519:stage3_begin->block-30-1776472411519:stage3_trust_m:jump|block-23-1776472411519:stage3_begin->block-31-1776472411519:stage3_trust_y:jump|block-24-1776472411519:stage3_night->block-34-1776472411519:stage4_begin:jump|block-25-1776472411519:stage3_partnership->block-26-1776472411519:stage3_revelation:jump|block-26-1776472411519:stage3_revelation->block-24-1776472411519:stage3_night:jump|block-27-1776472411519:stage3_trust_h->block-25-1776472411519:stage3_partnership:jump|block-28-1776472411519:stage3_trust_k->block-25-1776472411519:stage3_partnership:jump|block-29-1776472411519:stage3_trust_l->block-25-1776472411519:stage3_partnership:jump|block-30-1776472411519:stage3_trust_m->block-25-1776472411519:stage3_partnership:jump|block-31-1776472411519:stage3_trust_y->block-25-1776472411519:stage3_partnership:jump|block-32-1776472411519:stage4_analyze_clues->block-24-1776472411519:stage3_night:jump|block-32-1776472411519:stage4_analyze_clues->block-35-1776472411519:stage4_theory_binding:jump|block-32-1776472411519:stage4_analyze_clues->block-35-1776472411519:stage4_theory_coexist:jump|block-32-1776472411519:stage4_analyze_clues->block-35-1776472411519:stage4_theory_destroy:jump|block-32-1776472411519:stage4_analyze_clues->block-35-1776472411519:stage4_theory_exit:jump|block-33-1776472411519:stage4_artifact_history->block-39-1776472411519:stage4_garden_event:jump|block-34-1776472411519:stage4_begin->block-33-1776472411519:stage4_artifact_history:jump|block-35-1776472411519:stage4_decision->block-42-1776472411519:stage5_begin:jump|block-35-1776472411519:stage4_theory_binding->block-35-1776472411519:stage4_decision:jump|block-35-1776472411519:stage4_theory_coexist->block-35-1776472411519:stage4_decision:jump|block-35-1776472411519:stage4_theory_destroy->block-35-1776472411519:stage4_decision:jump|block-35-1776472411519:stage4_theory_exit->block-35-1776472411519:stage4_decision:jump|block-36-1776472411519:stage4_echo_desire->block-32-1776472411519:stage4_analyze_clues:jump|block-37-1776472411519:stage4_echo_effects->block-32-1776472411519:stage4_analyze_clues:jump|block-38-1776472411519:stage4_echo_liberation->block-40-1776472411519:stage4_suspect_s:jump|block-39-1776472411519:stage4_garden_event->block-36-1776472411519:stage4_echo_desire:jump|block-39-1776472411519:stage4_garden_event->block-37-1776472411519:stage4_echo_effects:jump|block-39-1776472411519:stage4_garden_event->block-38-1776472411519:stage4_echo_liberation:jump|block-40-1776472411519:stage4_suspect_s->block-32-1776472411519:stage4_analyze_clues:jump|block-41-1776472411519:stage5_art_room_crisis->block-44-1776472411519:stage5_emergency_meeting:jump|block-42-1776472411519:stage5_begin->block-41-1776472411519:stage5_art_room_crisis:jump|block-42-1776472411519:stage5_begin->block-43-1776472411519:stage5_computer_lab_crisis:jump|block-42-1776472411519:stage5_begin->block-45-1776472411519:stage5_gym_crisis:jump|block-43-1776472411519:stage5_computer_lab_crisis->block-44-1776472411519:stage5_emergency_meeting:jump|block-44-1776472411519:stage5_emergency_meeting->block-47-1776472411519:stage5_protect_path:jump|block-44-1776472411519:stage5_emergency_meeting->block-48-1776472411519:stage5_pursue_path:jump|block-45-1776472411519:stage5_gym_crisis->block-44-1776472411519:stage5_emergency_meeting:jump|block-46-1776472411519:stage5_phenomenon->block-44-1776472411519:stage5_emergency_meeting:jump|block-47-1776472411519:stage5_protect_path->block-49-1776472411519:stage6_begin:jump|block-48-1776472411519:stage5_pursue_path->block-49-1776472411519:stage6_begin:jump|block-49-1776472411519:stage6_begin->block-55-1776472411519:stage6_solo_investigation:jump|block-49-1776472411519:stage6_begin->block-56-1776472411519:stage6_team_formation:jump|block-50-1776472411519:stage6_evidence_compiled->block-54-1776472411519:stage6_preparation:jump|block-51-1776472411519:stage6_final_clue_library->block-50-1776472411519:stage6_evidence_compiled:jump|block-52-1776472411519:stage6_final_clue_occult->block-50-1776472411519:stage6_evidence_compiled:jump|block-53-1776472411519:stage6_final_clue_tech->block-50-1776472411519:stage6_evidence_compiled:jump|block-54-1776472411519:stage6_preparation->block-60-1776472411519:stage7_begin:jump|block-55-1776472411519:stage6_solo_investigation->block-51-1776472411519:stage6_final_clue_library:jump|block-55-1776472411519:stage6_solo_investigation->block-52-1776472411519:stage6_final_clue_occult:jump|block-55-1776472411519:stage6_solo_investigation->block-53-1776472411519:stage6_final_clue_tech:jump|block-56-1776472411519:stage6_team_formation->block-57-1776472411519:stage6_team_strategy:jump|block-57-1776472411519:stage6_team_strategy->block-50-1776472411519:stage6_evidence_compiled:jump|block-58-1776472411519:stage7_aftermath->block-68-1776472411519:stage8_begin:jump|block-59-1776472411519:stage7_battle->block-58-1776472411519:stage7_aftermath:jump|block-6-1776472411519:stage1_announcement->block-11-1776472411519:stage1_meet_h:jump|block-6-1776472411519:stage1_announcement->block-12-1776472411519:stage1_meet_s:jump|block-60-1776472411519:stage7_begin->block-61-1776472411519:stage7_challenge_echo:jump|block-60-1776472411519:stage7_begin->block-62-1776472411519:stage7_help_echo:jump|block-60-1776472411519:stage7_begin->block-64-1776472411519:stage7_negotiate_binding:jump|block-61-1776472411519:stage7_challenge_echo->block-59-1776472411519:stage7_battle:jump|block-61-1776472411519:stage7_challenge_echo->block-62-1776472411519:stage7_help_echo:jump|block-62-1776472411519:stage7_help_echo->block-65-1776472411519:stage7_ritual_self:jump|block-62-1776472411519:stage7_help_echo->block-65-1776472411519:stage7_ritual_self:jump|block-62-1776472411519:stage7_help_echo->block-66-1776472411519:stage7_ritual_shared:jump|block-62-1776472411519:stage7_help_echo->block-67-1776472411519:stage7_ritual_sterling:jump|block-63-1776472411519:stage7_integration->block-58-1776472411519:stage7_aftermath:jump|block-64-1776472411519:stage7_negotiate_binding->block-62-1776472411519:stage7_help_echo:jump|block-64-1776472411519:stage7_negotiate_binding->block-63-1776472411519:stage7_integration:jump|block-65-1776472411519:stage7_ritual_self->block-58-1776472411519:stage7_aftermath:jump|block-66-1776472411519:stage7_ritual_shared->block-58-1776472411519:stage7_aftermath:jump|block-67-1776472411519:stage7_ritual_sterling->block-58-1776472411519:stage7_aftermath:jump|block-68-1776472411519:stage8_begin->block-69-1776472411519:stage8_ending_battle_defeat:jump|block-68-1776472411519:stage8_begin->block-70-1776472411519:stage8_ending_battle_victory:jump|block-68-1776472411519:stage8_begin->block-71-1776472411519:stage8_ending_bittersweet:jump|block-68-1776472411519:stage8_begin->block-72-1776472411519:stage8_ending_integration:jump|block-68-1776472411519:stage8_begin->block-73-1776472411519:stage8_ending_self_sacrifice:jump|block-68-1776472411519:stage8_begin->block-74-1776472411519:stage8_ending_shared_perfect:jump|block-68-1776472411519:stage8_begin->block-75-1776472411519:stage8_ending_sterling_sacrifice:jump|block-69-1776472411519:stage8_ending_battle_defeat->block-76-1776472411519:stage8_epilogue_solo:jump|block-7-1776472411519:stage1_arrival->block-10-1776472411519:stage1_library_notice:jump|block-7-1776472411519:stage1_arrival->block-13-1776472411519:stage1_rumors:jump|block-7-1776472411519:stage1_arrival->block-6-1776472411519:stage1_announcement:jump|block-70-1776472411519:stage8_ending_battle_victory->block-76-1776472411519:stage8_epilogue_solo:jump|block-71-1776472411519:stage8_ending_bittersweet->block-77-1776472411519:stage8_epilogue_team:jump|block-72-1776472411519:stage8_ending_integration->block-77-1776472411519:stage8_epilogue_team:jump|block-73-1776472411519:stage8_ending_self_sacrifice->block-76-1776472411519:stage8_epilogue_solo:jump|block-74-1776472411519:stage8_ending_shared_perfect->block-77-1776472411519:stage8_epilogue_team:jump|block-75-1776472411519:stage8_ending_sterling_sacrifice->block-77-1776472411519:stage8_epilogue_team:jump|block-79-1776472411519:start->block-7-1776472411519:stage1_arrival:jump|block-8-1776472411519:stage1_choice->block-9-1776472411519:stage1_evening:jump|block-8-1776472411519:stage1_choice->block-9-1776472411519:stage1_evening:jump|block-8-1776472411519:stage1_choice->block-9-1776472411519:stage1_evening:jump|block-8-1776472411519:stage1_choice->block-9-1776472411519:stage1_evening:jump|block-9-1776472411519:stage1_evening->block-14-1776472411519:stage2_begin:jump|block-9-1776472411519:stage1_evening->block-5-1776472411519:TestScriptX:call",
+  "routeCanvasHasAutocentered": false,
+  "choiceCanvasHasAutocentered": false,
   "storyBlockLayouts": {
     "game/characters.rpy": {
       "position": {
@@ -56,6 +54,14 @@
       "position": {
         "x": 4900,
         "y": 850
+      },
+      "width": 320,
+      "height": 200
+    },
+    "game/scenes/stage1/TestScript.rpy": {
+      "position": {
+        "x": 6310,
+        "y": 725
       },
       "width": 320,
       "height": 200
@@ -119,14 +125,6 @@
     "game/scenes/stage1/stage1_rumors.rpy": {
       "position": {
         "x": 3020,
-        "y": 725
-      },
-      "width": 320,
-      "height": 200
-    },
-    "game/scenes/stage1/TestScript.rpy": {
-      "position": {
-        "x": 6310,
         "y": 725
       },
       "width": 320,
@@ -670,493 +668,493 @@
     }
   },
   "routeNodeLayouts": {
-    "block-4-1776336033891:clarity_file_maxim": {
+    "block-4-1776472411519:clarity_file_maxim": {
       "position": {
         "x": 1920,
         "y": 430
       }
     },
-    "block-5-1776336033891:stage1_announcement": {
+    "block-5-1776472411519:TestScriptX": {
+      "position": {
+        "x": 2880,
+        "y": 375
+      }
+    },
+    "block-6-1776472411519:stage1_announcement": {
       "position": {
         "x": 960,
         "y": 430
       }
     },
-    "block-6-1776336033891:stage1_arrival": {
+    "block-7-1776472411519:stage1_arrival": {
       "position": {
         "x": 320,
         "y": 430
       }
     },
-    "block-7-1776336033891:stage1_choice": {
+    "block-8-1776472411519:stage1_choice": {
       "position": {
         "x": 2240,
         "y": 430
       }
     },
-    "block-8-1776336033891:stage1_evening": {
+    "block-9-1776472411519:stage1_evening": {
       "position": {
         "x": 2560,
         "y": 430
       }
     },
-    "block-9-1776336033891:stage1_library_notice": {
+    "block-10-1776472411519:stage1_library_notice": {
       "position": {
         "x": 640,
         "y": 485
       }
     },
-    "block-10-1776336033891:stage1_meet_h": {
+    "block-11-1776472411519:stage1_meet_h": {
       "position": {
         "x": 1280,
         "y": 430
       }
     },
-    "block-11-1776336033891:stage1_meet_s": {
+    "block-12-1776472411519:stage1_meet_s": {
       "position": {
         "x": 1600,
         "y": 430
       }
     },
-    "block-12-1776336033891:stage1_rumors": {
+    "block-13-1776472411519:stage1_rumors": {
       "position": {
         "x": 640,
         "y": 375
       }
     },
-    "block-13-1776336033891:TestScriptX": {
-      "position": {
-        "x": 2880,
-        "y": 375
-      }
-    },
-    "block-14-1776336033891:stage2_begin": {
+    "block-14-1776472411519:stage2_begin": {
       "position": {
         "x": 2880,
         "y": 485
       }
     },
-    "block-15-1776336033891:stage2_converge": {
+    "block-15-1776472411519:stage2_converge": {
       "position": {
         "x": 4160,
         "y": 430
       }
     },
-    "block-16-1776336033891:stage2_library_clue": {
+    "block-16-1776472411519:stage2_library_clue": {
       "position": {
         "x": 3520,
         "y": 210
       }
     },
-    "block-17-1776336033891:stage2_library_path": {
+    "block-17-1776472411519:stage2_library_path": {
       "position": {
         "x": 3200,
         "y": 265
       }
     },
-    "block-18-1776336033891:stage2_occult_path": {
+    "block-18-1776472411519:stage2_occult_path": {
       "position": {
         "x": 3200,
         "y": 595
       }
     },
-    "block-19-1776336033891:stage2_social_clue": {
+    "block-19-1776472411519:stage2_social_clue": {
       "position": {
         "x": 3840,
         "y": 430
       }
     },
-    "block-20-1776336033891:stage2_social_path": {
+    "block-20-1776472411519:stage2_social_path": {
       "position": {
         "x": 3200,
         "y": 485
       }
     },
-    "block-20-1776336033891:stage2_interview_sterling": {
+    "block-20-1776472411519:stage2_interview_sterling": {
       "position": {
         "x": 3520,
         "y": 430
       }
     },
-    "block-20-1776336033891:stage2_interview_custodian": {
+    "block-20-1776472411519:stage2_interview_custodian": {
       "position": {
         "x": 3520,
         "y": 540
       }
     },
-    "block-20-1776336033891:stage2_interview_student": {
+    "block-20-1776472411519:stage2_interview_student": {
       "position": {
         "x": 3520,
         "y": 650
       }
     },
-    "block-21-1776336033891:stage2_tech_clue": {
+    "block-21-1776472411519:stage2_tech_clue": {
       "position": {
         "x": 3520,
         "y": 320
       }
     },
-    "block-22-1776336033891:stage2_tech_path": {
+    "block-22-1776472411519:stage2_tech_path": {
       "position": {
         "x": 3200,
         "y": 375
       }
     },
-    "block-23-1776336033891:stage3_begin": {
+    "block-23-1776472411519:stage3_begin": {
       "position": {
         "x": 4480,
         "y": 430
       }
     },
-    "block-24-1776336033891:stage3_night": {
+    "block-24-1776472411519:stage3_night": {
       "position": {
         "x": 5760,
         "y": 430
       }
     },
-    "block-25-1776336033891:stage3_partnership": {
+    "block-25-1776472411519:stage3_partnership": {
       "position": {
         "x": 5120,
         "y": 430
       }
     },
-    "block-26-1776336033891:stage3_revelation": {
+    "block-26-1776472411519:stage3_revelation": {
       "position": {
         "x": 5440,
         "y": 430
       }
     },
-    "block-27-1776336033891:stage3_trust_h": {
+    "block-27-1776472411519:stage3_trust_h": {
       "position": {
         "x": 4800,
         "y": 210
       }
     },
-    "block-28-1776336033891:stage3_trust_k": {
+    "block-28-1776472411519:stage3_trust_k": {
       "position": {
         "x": 4800,
         "y": 540
       }
     },
-    "block-29-1776336033891:stage3_trust_l": {
+    "block-29-1776472411519:stage3_trust_l": {
       "position": {
         "x": 4800,
         "y": 320
       }
     },
-    "block-30-1776336033891:stage3_trust_m": {
+    "block-30-1776472411519:stage3_trust_m": {
       "position": {
         "x": 4800,
         "y": 650
       }
     },
-    "block-31-1776336033891:stage3_trust_y": {
+    "block-31-1776472411519:stage3_trust_y": {
       "position": {
         "x": 4800,
         "y": 430
       }
     },
-    "block-32-1776336033891:stage4_analyze_clues": {
+    "block-32-1776472411519:stage4_analyze_clues": {
       "position": {
         "x": 7680,
         "y": 430
       }
     },
-    "block-33-1776336033891:stage4_artifact_history": {
+    "block-33-1776472411519:stage4_artifact_history": {
       "position": {
         "x": 6400,
         "y": 430
       }
     },
-    "block-34-1776336033891:stage4_begin": {
+    "block-34-1776472411519:stage4_begin": {
       "position": {
         "x": 6080,
         "y": 430
       }
     },
-    "block-35-1776336033891:stage4_theory_coexist": {
+    "block-35-1776472411519:stage4_theory_coexist": {
       "position": {
         "x": 8000,
         "y": 265
       }
     },
-    "block-35-1776336033891:stage4_theory_binding": {
+    "block-35-1776472411519:stage4_theory_binding": {
       "position": {
         "x": 8000,
         "y": 375
       }
     },
-    "block-35-1776336033891:stage4_theory_exit": {
+    "block-35-1776472411519:stage4_theory_exit": {
       "position": {
         "x": 8000,
         "y": 485
       }
     },
-    "block-35-1776336033891:stage4_theory_destroy": {
+    "block-35-1776472411519:stage4_theory_destroy": {
       "position": {
         "x": 8000,
         "y": 595
       }
     },
-    "block-35-1776336033891:stage4_decision": {
+    "block-35-1776472411519:stage4_decision": {
       "position": {
         "x": 8320,
         "y": 430
       }
     },
-    "block-36-1776336033891:stage4_echo_desire": {
+    "block-36-1776472411519:stage4_echo_desire": {
       "position": {
         "x": 7040,
         "y": 430
       }
     },
-    "block-37-1776336033891:stage4_echo_effects": {
+    "block-37-1776472411519:stage4_echo_effects": {
       "position": {
         "x": 7040,
         "y": 540
       }
     },
-    "block-38-1776336033891:stage4_echo_liberation": {
+    "block-38-1776472411519:stage4_echo_liberation": {
       "position": {
         "x": 7040,
         "y": 320
       }
     },
-    "block-39-1776336033891:stage4_garden_event": {
+    "block-39-1776472411519:stage4_garden_event": {
       "position": {
         "x": 6720,
         "y": 430
       }
     },
-    "block-40-1776336033891:stage4_suspect_s": {
+    "block-40-1776472411519:stage4_suspect_s": {
       "position": {
         "x": 7360,
         "y": 430
       }
     },
-    "block-41-1776336033891:stage5_art_room_crisis": {
+    "block-41-1776472411519:stage5_art_room_crisis": {
       "position": {
         "x": 8960,
         "y": 540
       }
     },
-    "block-42-1776336033891:stage5_begin": {
+    "block-42-1776472411519:stage5_begin": {
       "position": {
         "x": 8640,
         "y": 430
       }
     },
-    "block-43-1776336033891:stage5_computer_lab_crisis": {
+    "block-43-1776472411519:stage5_computer_lab_crisis": {
       "position": {
         "x": 8960,
         "y": 430
       }
     },
-    "block-44-1776336033891:stage5_emergency_meeting": {
+    "block-44-1776472411519:stage5_emergency_meeting": {
       "position": {
         "x": 9280,
         "y": 430
       }
     },
-    "block-45-1776336033891:stage5_gym_crisis": {
+    "block-45-1776472411519:stage5_gym_crisis": {
       "position": {
         "x": 8960,
         "y": 320
       }
     },
-    "block-46-1776336033891:stage5_phenomenon": {
+    "block-46-1776472411519:stage5_phenomenon": {
       "position": {
         "x": 0,
         "y": 375
       }
     },
-    "block-47-1776336033891:stage5_protect_path": {
+    "block-47-1776472411519:stage5_protect_path": {
       "position": {
         "x": 9600,
         "y": 375
       }
     },
-    "block-48-1776336033891:stage5_pursue_path": {
+    "block-48-1776472411519:stage5_pursue_path": {
       "position": {
         "x": 9600,
         "y": 485
       }
     },
-    "block-49-1776336033891:stage6_begin": {
+    "block-49-1776472411519:stage6_begin": {
       "position": {
         "x": 9920,
         "y": 430
       }
     },
-    "block-50-1776336033891:stage6_evidence_compiled": {
+    "block-50-1776472411519:stage6_evidence_compiled": {
       "position": {
         "x": 10880,
         "y": 430
       }
     },
-    "block-51-1776336033891:stage6_final_clue_library": {
+    "block-51-1776472411519:stage6_final_clue_library": {
       "position": {
         "x": 10560,
         "y": 375
       }
     },
-    "block-52-1776336033891:stage6_final_clue_occult": {
+    "block-52-1776472411519:stage6_final_clue_occult": {
       "position": {
         "x": 10560,
         "y": 595
       }
     },
-    "block-53-1776336033891:stage6_final_clue_tech": {
+    "block-53-1776472411519:stage6_final_clue_tech": {
       "position": {
         "x": 10560,
         "y": 485
       }
     },
-    "block-54-1776336033891:stage6_preparation": {
+    "block-54-1776472411519:stage6_preparation": {
       "position": {
         "x": 11200,
         "y": 430
       }
     },
-    "block-55-1776336033891:stage6_solo_investigation": {
+    "block-55-1776472411519:stage6_solo_investigation": {
       "position": {
         "x": 10240,
         "y": 485
       }
     },
-    "block-56-1776336033891:stage6_team_formation": {
+    "block-56-1776472411519:stage6_team_formation": {
       "position": {
         "x": 10240,
         "y": 375
       }
     },
-    "block-57-1776336033891:stage6_team_strategy": {
+    "block-57-1776472411519:stage6_team_strategy": {
       "position": {
         "x": 10560,
         "y": 265
       }
     },
-    "block-58-1776336033891:stage7_aftermath": {
+    "block-58-1776472411519:stage7_aftermath": {
       "position": {
         "x": 12800,
         "y": 430
       }
     },
-    "block-59-1776336033891:stage7_battle": {
+    "block-59-1776472411519:stage7_battle": {
       "position": {
         "x": 12160,
         "y": 430
       }
     },
-    "block-60-1776336033891:stage7_begin": {
+    "block-60-1776472411519:stage7_begin": {
       "position": {
         "x": 11520,
         "y": 430
       }
     },
-    "block-61-1776336033891:stage7_challenge_echo": {
+    "block-61-1776472411519:stage7_challenge_echo": {
       "position": {
         "x": 11840,
         "y": 485
       }
     },
-    "block-62-1776336033891:stage7_help_echo": {
+    "block-62-1776472411519:stage7_help_echo": {
       "position": {
         "x": 12160,
         "y": 540
       }
     },
-    "block-63-1776336033891:stage7_integration": {
+    "block-63-1776472411519:stage7_integration": {
       "position": {
         "x": 12160,
         "y": 320
       }
     },
-    "block-64-1776336033891:stage7_negotiate_binding": {
+    "block-64-1776472411519:stage7_negotiate_binding": {
       "position": {
         "x": 11840,
         "y": 375
       }
     },
-    "block-65-1776336033891:stage7_ritual_self": {
+    "block-65-1776472411519:stage7_ritual_self": {
       "position": {
         "x": 12480,
         "y": 320
       }
     },
-    "block-66-1776336033891:stage7_ritual_shared": {
+    "block-66-1776472411519:stage7_ritual_shared": {
       "position": {
         "x": 12480,
         "y": 540
       }
     },
-    "block-67-1776336033891:stage7_ritual_sterling": {
+    "block-67-1776472411519:stage7_ritual_sterling": {
       "position": {
         "x": 12480,
         "y": 430
       }
     },
-    "block-68-1776336033891:stage8_begin": {
+    "block-68-1776472411519:stage8_begin": {
       "position": {
         "x": 13120,
         "y": 430
       }
     },
-    "block-69-1776336033891:stage8_ending_battle_defeat": {
+    "block-69-1776472411519:stage8_ending_battle_defeat": {
       "position": {
         "x": 13440,
         "y": 650
       }
     },
-    "block-70-1776336033891:stage8_ending_battle_victory": {
+    "block-70-1776472411519:stage8_ending_battle_victory": {
       "position": {
         "x": 13440,
         "y": 540
       }
     },
-    "block-71-1776336033891:stage8_ending_bittersweet": {
+    "block-71-1776472411519:stage8_ending_bittersweet": {
       "position": {
         "x": 13440,
         "y": 760
       }
     },
-    "block-72-1776336033891:stage8_ending_integration": {
+    "block-72-1776472411519:stage8_ending_integration": {
       "position": {
         "x": 13440,
         "y": 430
       }
     },
-    "block-73-1776336033891:stage8_ending_self_sacrifice": {
+    "block-73-1776472411519:stage8_ending_self_sacrifice": {
       "position": {
         "x": 13440,
         "y": 100
       }
     },
-    "block-74-1776336033891:stage8_ending_shared_perfect": {
+    "block-74-1776472411519:stage8_ending_shared_perfect": {
       "position": {
         "x": 13440,
         "y": 320
       }
     },
-    "block-75-1776336033891:stage8_ending_sterling_sacrifice": {
+    "block-75-1776472411519:stage8_ending_sterling_sacrifice": {
       "position": {
         "x": 13440,
         "y": 210
       }
     },
-    "block-76-1776336033891:stage8_epilogue_solo": {
+    "block-76-1776472411519:stage8_epilogue_solo": {
       "position": {
         "x": 13760,
         "y": 375
       }
     },
-    "block-77-1776336033891:stage8_epilogue_team": {
+    "block-77-1776472411519:stage8_epilogue_team": {
       "position": {
         "x": 13760,
         "y": 485
       }
     },
-    "block-79-1776336033891:start": {
+    "block-79-1776472411519:start": {
       "position": {
         "x": 0,
         "y": 485
@@ -1165,23 +1163,28 @@
   },
   "openTabs": [
     {
-      "id": "block-5-1776336033891",
+      "id": "block-6-1776472411519",
       "type": "editor",
-      "blockId": "block-5-1776336033891",
+      "blockId": "block-6-1776472411519",
       "filePath": "game/scenes/stage1/stage1_announcement.rpy"
     },
     {
-      "id": "block-39-1776336033891",
+      "id": "block-39-1776472411519",
       "type": "editor",
-      "blockId": "block-39-1776336033891",
+      "blockId": "block-39-1776472411519",
       "filePath": "game/scenes/stage4/stage4_garden_event.rpy"
     },
     {
       "id": "canvas",
       "type": "canvas"
+    },
+    {
+      "id": "scene-1776436021630",
+      "type": "scene-composer",
+      "sceneId": "scene-1776436021630"
     }
   ],
-  "activeTabId": "canvas",
+  "activeTabId": "scene-1776436021630",
   "splitLayout": "none",
   "splitPrimarySize": 600,
   "secondaryOpenTabs": [],
@@ -1355,11 +1358,77 @@
           "blur": 0
         }
       ]
+    },
+    "scene-1776436021630": {
+      "background": null,
+      "sprites": [
+        {
+          "id": "sprite-1776436044979",
+          "image": {
+            "filePath": "game/images/cg/m.png"
+          },
+          "x": 0.27072945861539943,
+          "y": 0.47286794630977524,
+          "zoom": 0.75,
+          "zIndex": 1,
+          "flipH": false,
+          "flipV": false,
+          "rotation": 0,
+          "alpha": 1,
+          "blur": 0,
+          "visible": true,
+          "activeShader": "",
+          "shaderUniforms": {},
+          "colorMode": "colorize",
+          "colorizeBlack": "#36ad14",
+          "colorizeWhite": "#ff0000",
+          "saturation": 2
+        },
+        {
+          "id": "sprite-1776436192460",
+          "image": {
+            "filePath": "game/images/cg/m.png"
+          },
+          "x": 0.839001222875236,
+          "y": 0.4703033380292713,
+          "zoom": 0.77,
+          "zIndex": 2,
+          "flipH": false,
+          "flipV": false,
+          "rotation": 0,
+          "alpha": 1,
+          "blur": 0,
+          "visible": true,
+          "colorMode": "colorize",
+          "colorizeBlack": "#e00b0b",
+          "colorizeWhite": "#ffdd00",
+          "saturation": 1.45
+        },
+        {
+          "id": "sprite-1776472546932",
+          "image": {
+            "filePath": "game/images/cg/l.png"
+          },
+          "x": 0.5320655953555828,
+          "y": 0.4997848388425016,
+          "zoom": 0.93,
+          "zIndex": 3,
+          "flipH": true,
+          "flipV": false,
+          "rotation": null,
+          "alpha": 1,
+          "blur": 0,
+          "visible": true,
+          "colorMode": "colorize",
+          "saturation": 0
+        }
+      ]
     }
   },
   "sceneNames": {
     "scene-1764262740876": "Garden",
-    "scene-1764262795876": "Nascent"
+    "scene-1764262795876": "Nascent",
+    "scene-1776436021630": "Sprite Composer"
   },
   "imagemapCompositions": {
     "imagemap-1775273324257": {

--- a/components/MatrixPresetPopover.tsx
+++ b/components/MatrixPresetPopover.tsx
@@ -1,0 +1,163 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import type { SceneSprite } from '../types';
+
+interface MatrixPreset {
+    name: string;
+    swatch: string; // CSS background value (color or gradient)
+    apply: Partial<SceneSprite>;
+}
+
+interface PresetCategory {
+    label: string;
+    presets: MatrixPreset[];
+}
+
+const RESET: Partial<SceneSprite> = {
+    colorMode: 'none',
+    tintColor: '#ffffff',
+    colorizeBlack: '#000000',
+    colorizeWhite: '#ffffff',
+    saturation: 1.0,
+    brightness: 0,
+    contrast: 1.0,
+    invert: 0,
+};
+
+const PRESET_CATEGORIES: PresetCategory[] = [
+    {
+        label: 'Environmental & Time of Day',
+        presets: [
+            { name: 'Night',             swatch: '#444466',                                            apply: { ...RESET, colorMode: 'tint', tintColor: '#444466', brightness: -0.1 } },
+            { name: 'Sunset',            swatch: '#ffcc99',                                            apply: { ...RESET, colorMode: 'tint', tintColor: '#ffcc99', brightness: 0.05 } },
+            { name: 'Evening / Dusk',    swatch: '#8866aa',                                            apply: { ...RESET, colorMode: 'tint', tintColor: '#8866aa' } },
+            { name: 'Early Morning',     swatch: '#b2cce6',                                            apply: { ...RESET, colorMode: 'tint', tintColor: '#b2cce6' } },
+            { name: 'Midday / Harsh Sun', swatch: 'linear-gradient(135deg, #ffffcc, #ffffff)',         apply: { ...RESET, brightness: 0.1, contrast: 1.2 } },
+        ],
+    },
+    {
+        label: 'Flashbacks & Memory',
+        presets: [
+            { name: 'Classic Sepia',   swatch: 'linear-gradient(135deg, #704214, #f5e4c3)',            apply: { ...RESET, colorMode: 'colorize', colorizeBlack: '#704214', colorizeWhite: '#f5e4c3' } },
+            { name: 'Greyscale',       swatch: 'linear-gradient(135deg, #222, #ddd)',                  apply: { ...RESET, saturation: 0 } },
+            { name: 'Noir',            swatch: 'linear-gradient(135deg, #000, #fff)',                  apply: { ...RESET, saturation: 0, contrast: 1.5 } },
+            { name: 'Faded Memory',    swatch: '#d4d4d4',                                              apply: { ...RESET, saturation: 0.5, brightness: 0.1 } },
+        ],
+    },
+    {
+        label: 'Character State',
+        presets: [
+            { name: 'Silhouette',       swatch: '#000000',                                            apply: { ...RESET, brightness: -1.0 } },
+            { name: 'Dimmed (Inactive)', swatch: '#555566',                                           apply: { ...RESET, brightness: -0.2, saturation: 0.8 } },
+            { name: 'Ghost / Spirit',   swatch: '#aaffff',                                            apply: { ...RESET, colorMode: 'tint', tintColor: '#aaffff' } },
+            { name: 'Blushing',         swatch: '#ffcccc',                                            apply: { ...RESET, colorMode: 'tint', tintColor: '#ffcccc' } },
+            { name: 'Cold / Sick',      swatch: '#e6ffff',                                            apply: { ...RESET, colorMode: 'tint', tintColor: '#e6ffff', saturation: 0.6 } },
+        ],
+    },
+    {
+        label: 'Horror & Special Effects',
+        presets: [
+            { name: 'Invert',         swatch: 'linear-gradient(135deg, #ff0066, #00ffcc, #ffcc00)',   apply: { ...RESET, invert: 1.0 } },
+            { name: 'Blood Red',      swatch: 'linear-gradient(135deg, #220000, #ff0000)',            apply: { ...RESET, colorMode: 'colorize', colorizeBlack: '#220000', colorizeWhite: '#ff0000' } },
+            { name: 'Toxic / Poison', swatch: 'linear-gradient(135deg, #002200, #55ff55)',            apply: { ...RESET, colorMode: 'colorize', colorizeBlack: '#002200', colorizeWhite: '#55ff55' } },
+            { name: 'Night Vision',   swatch: '#00ff00',                                              apply: { ...RESET, colorMode: 'tint', tintColor: '#00ff00', brightness: 0.1, contrast: 1.5 } },
+        ],
+    },
+    {
+        label: 'UI & Technical',
+        presets: [
+            { name: 'Disabled',          swatch: '#888888',                                           apply: { ...RESET, saturation: 0, brightness: -0.1 } },
+            { name: 'Highlighted / Glow', swatch: 'linear-gradient(135deg, #ffffaa, #ffffff)',        apply: { ...RESET, brightness: 0.2, contrast: 1.1 } },
+        ],
+    },
+];
+
+interface Props {
+    onApply: (updates: Partial<SceneSprite>) => void;
+}
+
+const MatrixPresetPopover: React.FC<Props> = ({ onApply }) => {
+    const [open, setOpen] = useState(false);
+    const [pos, setPos] = useState({ top: 0, left: 0, maxWidth: 256 });
+    const buttonRef = useRef<HTMLButtonElement>(null);
+
+    useEffect(() => {
+        if (!open) return;
+        const handleMouseDown = () => setOpen(false);
+        document.addEventListener('mousedown', handleMouseDown);
+        return () => document.removeEventListener('mousedown', handleMouseDown);
+    }, [open]);
+
+    const handleToggle = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        if (!open && buttonRef.current) {
+            const rect = buttonRef.current.getBoundingClientRect();
+            const spaceBelow = window.innerHeight - rect.bottom;
+            const spaceAbove = rect.top;
+            const popoverHeight = Math.min(400, window.innerHeight * 0.6);
+            const top = spaceBelow >= popoverHeight || spaceBelow >= spaceAbove
+                ? rect.bottom + 4
+                : rect.top - popoverHeight - 4;
+            setPos({ top, left: Math.min(rect.left, window.innerWidth - 264), maxWidth: 256 });
+        }
+        setOpen(v => !v);
+    };
+
+    const handlePreset = (preset: MatrixPreset, e: React.MouseEvent) => {
+        e.stopPropagation();
+        onApply(preset.apply);
+        setOpen(false);
+    };
+
+    return (
+        <>
+            <button
+                ref={buttonRef}
+                onClick={handleToggle}
+                className="flex items-center gap-1 px-2 py-1 text-[10px] font-medium rounded border border-indigo-300 dark:border-indigo-600 bg-indigo-50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-100 dark:hover:bg-indigo-900/50 whitespace-nowrap"
+            >
+                <svg className="w-3 h-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+                </svg>
+                <span>Presets</span>
+                <svg className="w-2.5 h-2.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                </svg>
+            </button>
+
+            {open && createPortal(
+                <div
+                    style={{ top: pos.top, left: pos.left, maxHeight: 400, width: pos.maxWidth }}
+                    className="fixed z-[9999] overflow-y-auto rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-2xl"
+                    onMouseDown={e => e.stopPropagation()}
+                >
+                    {PRESET_CATEGORIES.map(cat => (
+                        <div key={cat.label}>
+                            <div className="px-3 py-1.5 bg-gray-50 dark:bg-gray-700/80 border-b border-gray-100 dark:border-gray-700 sticky top-0">
+                                <span className="text-[9px] font-bold text-gray-400 dark:text-gray-500 uppercase tracking-wide">
+                                    {cat.label}
+                                </span>
+                            </div>
+                            {cat.presets.map(preset => (
+                                <button
+                                    key={preset.name}
+                                    onMouseDown={e => handlePreset(preset, e)}
+                                    className="w-full flex items-center gap-2.5 px-3 py-1.5 text-left hover:bg-indigo-50 dark:hover:bg-indigo-900/20 transition-colors"
+                                >
+                                    <span
+                                        className="w-5 h-5 rounded-sm flex-shrink-0 border border-black/10 dark:border-white/10"
+                                        style={{ background: preset.swatch }}
+                                    />
+                                    <span className="text-[11px] text-gray-700 dark:text-gray-300">{preset.name}</span>
+                                </button>
+                            ))}
+                        </div>
+                    ))}
+                </div>,
+                document.body
+            )}
+        </>
+    );
+};
+
+export default MatrixPresetPopover;

--- a/components/SceneComposer.tsx
+++ b/components/SceneComposer.tsx
@@ -33,6 +33,9 @@ function spriteVisualFilter(sprite: SceneSprite): string {
     const parts: string[] = [];
     const colorMode = sprite.colorMode ?? 'none';
     const saturation = sprite.saturation ?? 1.0;
+    const brightness = sprite.brightness ?? 0;
+    const contrast = sprite.contrast ?? 1.0;
+    const invert = sprite.invert ?? 0;
     const activeShader = sprite.activeShader ?? '';
     const uniforms = sprite.shaderUniforms ?? {};
 
@@ -52,6 +55,10 @@ function spriteVisualFilter(sprite: SceneSprite): string {
         parts.push(`saturate(${saturation})`);
     }
 
+    if (brightness !== 0) parts.push(`brightness(${(1 + brightness).toFixed(2)})`);
+    if (contrast !== 1.0) parts.push(`contrast(${contrast.toFixed(2)})`);
+    if (invert !== 0) parts.push(`invert(${invert.toFixed(2)})`);
+
     return parts.length > 0 ? parts.join(' ') : 'none';
 }
 
@@ -60,27 +67,23 @@ function spriteEffectCode(sprite: SceneSprite, indent = '    '): string {
     let code = '';
     const colorMode = sprite.colorMode ?? 'none';
     const saturation = sprite.saturation ?? 1.0;
+    const brightness = sprite.brightness ?? 0;
+    const contrast = sprite.contrast ?? 1.0;
+    const invert = sprite.invert ?? 0;
     const activeShader = sprite.activeShader ?? '';
     const uniforms = sprite.shaderUniforms ?? {};
 
-    if (colorMode !== 'none') {
-        let matrixExpr = '';
-        if (colorMode === 'tint' && sprite.tintColor) {
-            matrixExpr = `TintMatrix("${sprite.tintColor}")`;
-        } else if (colorMode === 'colorize') {
-            const black = sprite.colorizeBlack ?? '#000000';
-            const white = sprite.colorizeWhite ?? '#ffffff';
-            matrixExpr = `ColorizeMatrix("${black}", "${white}")`;
-        }
-        if (matrixExpr && saturation !== 1.0) {
-            matrixExpr += ` * SaturationMatrix(${saturation.toFixed(2)})`;
-        } else if (!matrixExpr && saturation !== 1.0) {
-            matrixExpr = `SaturationMatrix(${saturation.toFixed(2)})`;
-        }
-        if (matrixExpr) code += `${indent}matrixcolor ${matrixExpr}\n`;
-    } else if (saturation !== 1.0) {
-        code += `${indent}matrixcolor SaturationMatrix(${saturation.toFixed(2)})\n`;
+    const matrixParts: string[] = [];
+    if (colorMode === 'tint' && sprite.tintColor) {
+        matrixParts.push(`TintMatrix("${sprite.tintColor}")`);
+    } else if (colorMode === 'colorize') {
+        matrixParts.push(`ColorizeMatrix("${sprite.colorizeBlack ?? '#000000'}", "${sprite.colorizeWhite ?? '#ffffff'}")`);
     }
+    if (saturation !== 1.0) matrixParts.push(`SaturationMatrix(${saturation.toFixed(2)})`);
+    if (brightness !== 0) matrixParts.push(`BrightnessMatrix(${brightness.toFixed(2)})`);
+    if (contrast !== 1.0) matrixParts.push(`ContrastMatrix(${contrast.toFixed(2)})`);
+    if (invert !== 0) matrixParts.push(`InvertMatrix(${invert.toFixed(2)})`);
+    if (matrixParts.length > 0) code += `${indent}matrixcolor ${matrixParts.join(' * ')}\n`;
 
     if (activeShader) {
         code += `${indent}shader "${activeShader}"\n`;

--- a/components/SceneComposer.tsx
+++ b/components/SceneComposer.tsx
@@ -9,6 +9,162 @@
 import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import type { ProjectImage, ImageMetadata, SceneComposition, SceneSprite } from '../types';
 import CopyButton from './CopyButton';
+import SceneSpriteProperties from './SceneSpriteProperties';
+
+// Returns the hue-rotate degrees needed to tint an image from sepia baseline (~38°) to the target hex color
+function hexToHueDeg(hex: string): number {
+    const r = parseInt(hex.slice(1, 3), 16) / 255;
+    const g = parseInt(hex.slice(3, 5), 16) / 255;
+    const b = parseInt(hex.slice(5, 7), 16) / 255;
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    const d = max - min;
+    if (d === 0) return 0;
+    let h = 0;
+    if (max === r) h = ((g - b) / d + 6) % 6;
+    else if (max === g) h = (b - r) / d + 2;
+    else h = (r - g) / d + 4;
+    const targetHue = Math.round(h * 60);
+    return (targetHue - 38 + 360) % 360;
+}
+
+// Builds a CSS filter string approximating Ren'Py matrixcolor/shader effects for live preview
+function spriteVisualFilter(sprite: SceneSprite): string {
+    const parts: string[] = [];
+    const colorMode = sprite.colorMode ?? 'none';
+    const saturation = sprite.saturation ?? 1.0;
+    const activeShader = sprite.activeShader ?? '';
+    const uniforms = sprite.shaderUniforms ?? {};
+
+    // renpy.blur uses log2 scale; convert to CSS px via 2^n. Fall back to the legacy blur field.
+    const blurPx = activeShader === 'renpy.blur'
+        ? Math.pow(2, uniforms['u_renpy_blur_log2'] ?? 1)
+        : (sprite.blur ?? 0);
+    if (blurPx > 0) parts.push(`blur(${blurPx.toFixed(1)}px)`);
+
+    if (colorMode === 'tint' && sprite.tintColor) {
+        const hue = hexToHueDeg(sprite.tintColor);
+        parts.push('sepia(1)', `hue-rotate(${hue}deg)`, `saturate(${(saturation * 3).toFixed(2)})`);
+    } else if (colorMode === 'colorize' && sprite.colorizeWhite) {
+        const hue = hexToHueDeg(sprite.colorizeWhite);
+        parts.push('sepia(1)', `hue-rotate(${hue}deg)`, `saturate(${(saturation * 2).toFixed(2)})`);
+    } else if (saturation !== 1.0) {
+        parts.push(`saturate(${saturation})`);
+    }
+
+    return parts.length > 0 ? parts.join(' ') : 'none';
+}
+
+// Builds the matrixcolor + shader lines for the Ren'Py ATL code generator
+function spriteEffectCode(sprite: SceneSprite, indent = '    '): string {
+    let code = '';
+    const colorMode = sprite.colorMode ?? 'none';
+    const saturation = sprite.saturation ?? 1.0;
+    const activeShader = sprite.activeShader ?? '';
+    const uniforms = sprite.shaderUniforms ?? {};
+
+    if (colorMode !== 'none') {
+        let matrixExpr = '';
+        if (colorMode === 'tint' && sprite.tintColor) {
+            matrixExpr = `TintMatrix("${sprite.tintColor}")`;
+        } else if (colorMode === 'colorize') {
+            const black = sprite.colorizeBlack ?? '#000000';
+            const white = sprite.colorizeWhite ?? '#ffffff';
+            matrixExpr = `ColorizeMatrix("${black}", "${white}")`;
+        }
+        if (matrixExpr && saturation !== 1.0) {
+            matrixExpr += ` * SaturationMatrix(${saturation.toFixed(2)})`;
+        } else if (!matrixExpr && saturation !== 1.0) {
+            matrixExpr = `SaturationMatrix(${saturation.toFixed(2)})`;
+        }
+        if (matrixExpr) code += `${indent}matrixcolor ${matrixExpr}\n`;
+    } else if (saturation !== 1.0) {
+        code += `${indent}matrixcolor SaturationMatrix(${saturation.toFixed(2)})\n`;
+    }
+
+    if (activeShader) {
+        code += `${indent}shader "${activeShader}"\n`;
+        Object.entries(uniforms).forEach(([k, v]) => {
+            code += `${indent}${k} ${v}\n`;
+        });
+    }
+
+    return code;
+}
+
+interface SpritePreviewImageProps {
+    sprite: SceneSprite;
+    isBackground: boolean;
+}
+
+const SpritePreviewImage: React.FC<SpritePreviewImageProps> = ({ sprite, isBackground }) => {
+    const [naturalSize, setNaturalSize] = React.useState<{ w: number; h: number } | null>(null);
+
+    const isPixelize = sprite.activeShader === 'renpy.pixelize';
+    const uniforms = sprite.shaderUniforms ?? {};
+    const uAmount = uniforms['u_amount'] ?? 0.01;
+
+    const baseTransform = `rotate(${sprite.rotation}deg) scale(${sprite.zoom || 1}) scaleX(${sprite.flipH ? -1 : 1}) scaleY(${sprite.flipV ? -1 : 1})`;
+
+    if (isPixelize && naturalSize) {
+        // Downscale to (blockSize x blockSize) resolution, then CSS-scale back up with pixelated rendering.
+        // u_amount maps 0.001–0.1 → blockSize 1–20 so the effect is visible at typical slider values.
+        const blockSize = Math.max(1, Math.round(uAmount * 200));
+        const downW = Math.max(1, Math.round(naturalSize.w / blockSize));
+        const downH = Math.max(1, Math.round(naturalSize.h / blockSize));
+        const upScale = naturalSize.w / downW;
+
+        return (
+            <div
+                style={{
+                    width: naturalSize.w,
+                    height: naturalSize.h,
+                    overflow: 'hidden',
+                    transform: baseTransform,
+                    transformOrigin: 'center center',
+                    opacity: sprite.alpha ?? 1,
+                    flexShrink: 0,
+                }}
+                className="pointer-events-none block select-none"
+            >
+                <img
+                    src={sprite.image.dataUrl}
+                    width={downW}
+                    height={downH}
+                    style={{
+                        imageRendering: 'pixelated',
+                        transform: `scale(${upScale})`,
+                        transformOrigin: 'top left',
+                        display: 'block',
+                    }}
+                    className="pointer-events-none select-none"
+                />
+            </div>
+        );
+    }
+
+    return (
+        <img
+            src={sprite.image.dataUrl}
+            onLoad={e => {
+                const img = e.currentTarget;
+                setNaturalSize({ w: img.naturalWidth, h: img.naturalHeight });
+            }}
+            style={{
+                height: isBackground ? '100%' : 'auto',
+                width: isBackground ? '100%' : 'auto',
+                objectFit: isBackground ? 'fill' : undefined,
+                maxWidth: 'none',
+                maxHeight: 'none',
+                transform: baseTransform,
+                transformOrigin: 'center center',
+                opacity: sprite.alpha ?? 1,
+                filter: spriteVisualFilter(sprite),
+            }}
+            className="pointer-events-none block select-none"
+        />
+    );
+};
 
 const PRESET_RESOLUTIONS = [
     { label: '1920×1080 (16:9)', width: 1920, height: 1080 },
@@ -33,7 +189,31 @@ const SceneComposer: React.FC<SceneComposerProps> = ({ images, metadata, scene, 
     const [isRenaming, setIsRenaming] = useState(false);
     const [editName, setEditName] = useState(sceneName);
     const [isExporting, setIsExporting] = useState(false);
-    
+
+    // Undo / Redo
+    const [undoStack, setUndoStack] = useState<SceneComposition[]>([]);
+    const [redoStack, setRedoStack] = useState<SceneComposition[]>([]);
+    const saveUndo = useCallback(() => {
+        setUndoStack(prev => [...prev.slice(-49), scene]);
+        setRedoStack([]);
+    }, [scene]);
+
+    const handleUndo = useCallback(() => {
+        if (undoStack.length === 0) return;
+        const prev = undoStack[undoStack.length - 1];
+        setRedoStack(r => [scene, ...r.slice(0, 49)]);
+        setUndoStack(u => u.slice(0, -1));
+        onSceneChange(prev);
+    }, [undoStack, scene, onSceneChange]);
+
+    const handleRedo = useCallback(() => {
+        if (redoStack.length === 0) return;
+        const next = redoStack[0];
+        setUndoStack(u => [...u.slice(-49), scene]);
+        setRedoStack(r => r.slice(1));
+        onSceneChange(next);
+    }, [redoStack, scene, onSceneChange]);
+
     // Layer List Drag State
     const [dragOverInfo, setDragOverInfo] = useState<{ id: string, position: 'top' | 'bottom' } | null>(null);
     
@@ -120,6 +300,7 @@ const SceneComposer: React.FC<SceneComposerProps> = ({ images, metadata, scene, 
                 flipH: false, flipV: false, rotation: 0, alpha: 1.0, blur: 0,
                 visible: true
             };
+            saveUndo();
             onSceneChange(prev => ({ ...prev, background: newBg }));
             setSelectedSpriteId('background');
         } else {
@@ -144,6 +325,7 @@ const SceneComposer: React.FC<SceneComposerProps> = ({ images, metadata, scene, 
                     blur: 0,
                     visible: true
                 };
+                saveUndo();
                 onSceneChange(prev => ({ ...prev, sprites: [...prev.sprites, newSprite] }));
                 setSelectedSpriteId(newSprite.id);
             }
@@ -156,7 +338,9 @@ const SceneComposer: React.FC<SceneComposerProps> = ({ images, metadata, scene, 
     };
 
     // Sprite Manipulation
-    const updateSprite = (id: string, updates: Partial<SceneSprite>) => {
+    const updateSprite = useCallback((id: string, updates: Partial<SceneSprite>) => {
+        // Skip undo snapshot during pointer drag — handlePointerDown already captured it
+        if (!draggingId) saveUndo();
         if (id === 'background') {
             onSceneChange(prev => prev.background ? ({ ...prev, background: { ...prev.background, ...updates } }) : prev);
         } else {
@@ -165,7 +349,7 @@ const SceneComposer: React.FC<SceneComposerProps> = ({ images, metadata, scene, 
                 sprites: prev.sprites.map(s => s.id === id ? { ...s, ...updates } : s)
             }));
         }
-    };
+    }, [draggingId, saveUndo, onSceneChange]);
 
     const toggleVisibility = (id: string) => {
         if (id === 'background') {
@@ -186,6 +370,7 @@ const SceneComposer: React.FC<SceneComposerProps> = ({ images, metadata, scene, 
     };
 
     const removeSprite = useCallback((id: string) => {
+        saveUndo();
         if (id === 'background') {
             onSceneChange(prev => ({ ...prev, background: null }));
         } else {
@@ -197,14 +382,20 @@ const SceneComposer: React.FC<SceneComposerProps> = ({ images, metadata, scene, 
             });
         }
         if (selectedSpriteId === id) setSelectedSpriteId(null);
-    }, [onSceneChange, selectedSpriteId]);
+    }, [onSceneChange, selectedSpriteId, saveUndo]);
 
     // Keyboard Shortcuts
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
             // Ignore if typing in an input
             if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
-            
+
+            const mod = e.ctrlKey || e.metaKey;
+
+            // Undo / Redo (handled regardless of selection)
+            if (mod && e.key === 'z' && !e.shiftKey) { e.preventDefault(); handleUndo(); return; }
+            if (mod && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) { e.preventDefault(); handleRedo(); return; }
+
             if (!selectedSpriteId) return;
 
             if (e.key === 'Escape') {
@@ -230,6 +421,7 @@ const SceneComposer: React.FC<SceneComposerProps> = ({ images, metadata, scene, 
 
                 if (dx !== 0 || dy !== 0) {
                     e.preventDefault();
+                    saveUndo();
                     onSceneChange(prev => ({
                         ...prev,
                         sprites: prev.sprites.map(s => {
@@ -255,9 +447,10 @@ const SceneComposer: React.FC<SceneComposerProps> = ({ images, metadata, scene, 
         return () => {
             if (container) container.removeEventListener('keydown', handleKeyDown);
         };
-    }, [onSceneChange, removeSprite, selectedSpriteId]);
+    }, [onSceneChange, removeSprite, selectedSpriteId, handleUndo, handleRedo, saveUndo]);
 
     const moveSpriteToGap = (fromIndex: number, gapIndex: number) => {
+        saveUndo();
         onSceneChange(prev => {
             const newSprites = [...prev.sprites];
             const insertionIndex = fromIndex < gapIndex ? gapIndex - 1 : gapIndex;
@@ -274,6 +467,7 @@ const SceneComposer: React.FC<SceneComposerProps> = ({ images, metadata, scene, 
 
     const setSpriteAsBackground = (id: string) => {
         if (id === 'background') return;
+        saveUndo();
         onSceneChange(prev => {
             const sprite = prev.sprites.find(s => s.id === id);
             if (!sprite) return prev;
@@ -327,7 +521,7 @@ const SceneComposer: React.FC<SceneComposerProps> = ({ images, metadata, scene, 
                 ctx.rotate(bgSprite.rotation * Math.PI / 180);
                 ctx.scale((bgSprite.zoom || 1) * (bgSprite.flipH ? -1 : 1), (bgSprite.zoom || 1) * (bgSprite.flipV ? -1 : 1));
                 ctx.globalAlpha = bgSprite.alpha ?? 1;
-                if (bgSprite.blur) ctx.filter = `blur(${bgSprite.blur}px)`;
+                ctx.filter = spriteVisualFilter(bgSprite);
                 
                 // Draw centered
                 ctx.drawImage(img, -REF_WIDTH / 2, -REF_HEIGHT / 2, REF_WIDTH, REF_HEIGHT);
@@ -344,7 +538,7 @@ const SceneComposer: React.FC<SceneComposerProps> = ({ images, metadata, scene, 
                     ctx.rotate(sprite.rotation * Math.PI / 180);
                     ctx.scale((sprite.zoom || 1) * (sprite.flipH ? -1 : 1), (sprite.zoom || 1) * (sprite.flipV ? -1 : 1));
                     ctx.globalAlpha = sprite.alpha ?? 1;
-                    if (sprite.blur) ctx.filter = `blur(${sprite.blur}px)`;
+                    ctx.filter = spriteVisualFilter(sprite);
                     
                     // Draw centered at natural size
                     ctx.drawImage(img, -img.naturalWidth / 2, -img.naturalHeight / 2);
@@ -403,6 +597,7 @@ const SceneComposer: React.FC<SceneComposerProps> = ({ images, metadata, scene, 
         if (id !== 'background') {
             const sprite = scene.sprites.find(s => s.id === id);
             if (!(sprite?.locked ?? false)) {
+                saveUndo();
                 setDraggingId(id);
                 (e.target as HTMLElement).setPointerCapture(e.pointerId);
             }
@@ -489,10 +684,12 @@ const SceneComposer: React.FC<SceneComposerProps> = ({ images, metadata, scene, 
             if (bg.rotation !== 0) transforms.push(`rotate ${bg.rotation}`);
             if (bg.alpha !== 1.0) transforms.push(`alpha ${bg.alpha}`);
             if (bg.blur > 0) transforms.push(`blur ${bg.blur}`);
-            
+
+            const bgEffects = spriteEffectCode(bg);
             let bgCode: string;
-            if (transforms.length > 0) {
-                bgCode = `scene ${tag}:\n    ${transforms.join('\n    ')}\n`;
+            if (transforms.length > 0 || bgEffects) {
+                bgCode = `scene ${tag}:\n    ${transforms.join('\n    ')}${transforms.length > 0 ? '\n' : ''}${bgEffects}`;
+                if (!bgCode.endsWith('\n')) bgCode += '\n';
             } else {
                 bgCode = `scene ${tag}\n`;
             }
@@ -520,7 +717,8 @@ const SceneComposer: React.FC<SceneComposerProps> = ({ images, metadata, scene, 
             const zStr = ` zorder ${index + 1}`;
             
             // Ren'Py xcenter/ycenter aligns with the visual editor's center point logic
-            let spriteCode = `show ${tag}${zStr}:\n    xcenter ${x} ycenter ${y}${zoomStr}${xzoomStr}${yzoomStr}${rotateStr}${alphaStr}${blurStr}\n`;
+            const effectCode = spriteEffectCode(sprite);
+            let spriteCode = `show ${tag}${zStr}:\n    xcenter ${x} ycenter ${y}${zoomStr}${xzoomStr}${yzoomStr}${rotateStr}${alphaStr}${blurStr}\n${effectCode}`;
             
             if (sprite.visible === false) {
                 spriteCode = spriteCode.split('\n').map(l => l.trim() ? `# ${l}` : l).join('\n');
@@ -539,33 +737,6 @@ const SceneComposer: React.FC<SceneComposerProps> = ({ images, metadata, scene, 
         return scene.sprites.map((s, index) => ({ sprite: s, originalIndex: index })).reverse();
     }, [scene.sprites]);
 
-    // Render Helpers
-    const renderSpriteImage = (sprite: SceneSprite, isBackground: boolean) => (
-        <img 
-            src={sprite.image.dataUrl} 
-            style={{ 
-                height: isBackground ? '100%' : 'auto',
-                width: isBackground ? '100%' : 'auto',
-                objectFit: isBackground ? 'fill' : undefined,
-                maxWidth: 'none',
-                maxHeight: 'none',
-                transform: `rotate(${sprite.rotation}deg) scale(${sprite.zoom || 1}) scaleX(${sprite.flipH ? -1 : 1}) scaleY(${sprite.flipV ? -1 : 1})`,
-                transformOrigin: 'center center',
-                opacity: sprite.alpha ?? 1,
-                filter: sprite.blur ? `blur(${sprite.blur}px)` : 'none',
-            }}
-            className="pointer-events-none block select-none"
-        />
-    );
-
-    const ControlGroup: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
-        <div className="flex flex-col space-y-1.5 p-2 bg-gray-50 dark:bg-gray-700/50 rounded border border-gray-200 dark:border-gray-600">
-            <span className="text-[10px] font-bold text-gray-50 dark:text-gray-400 uppercase tracking-wide">{label}</span>
-            <div className="flex items-center space-x-2">
-                {children}
-            </div>
-        </div>
-    );
 
     const handleLayerListDragOver = (e: React.DragEvent, id: string, _originalIndex: number) => {
         e.preventDefault();
@@ -596,17 +767,19 @@ const SceneComposer: React.FC<SceneComposerProps> = ({ images, metadata, scene, 
         } else {
             const [w, h] = val.split('x').map(Number);
             setShowCustomInputs(false);
+            saveUndo();
             onSceneChange(prev => ({ ...prev, resolution: { width: w, height: h } }));
         }
-    }, [onSceneChange]);
+    }, [onSceneChange, saveUndo]);
 
     const applyCustomResolution = useCallback(() => {
         const w = parseInt(customW);
         const h = parseInt(customH);
         if (w > 0 && h > 0) {
+            saveUndo();
             onSceneChange(prev => ({ ...prev, resolution: { width: w, height: h } }));
         }
-    }, [customW, customH, onSceneChange]);
+    }, [customW, customH, onSceneChange, saveUndo]);
 
     const resolutionDropdownValue = (showCustomInputs || isCustomResolution) ? 'custom' : `${REF_WIDTH}x${REF_HEIGHT}`;
     const showResolutionInputs = showCustomInputs || isCustomResolution;
@@ -731,7 +904,7 @@ const SceneComposer: React.FC<SceneComposerProps> = ({ images, metadata, scene, 
                             style={{ zIndex: 0, pointerEvents: scene.background.locked ? 'none' : 'auto' }}
                             onPointerDown={(e) => handlePointerDown(e, 'background')}
                         >
-                            {renderSpriteImage(scene.background, true)}
+                            <SpritePreviewImage sprite={scene.background} isBackground={true} />
                         </div>
                     )}
                     
@@ -762,7 +935,7 @@ const SceneComposer: React.FC<SceneComposerProps> = ({ images, metadata, scene, 
                                 onPointerDown={(e) => handlePointerDown(e, sprite.id)}
                                 onWheel={(e) => handleWheel(e, sprite.id)}
                             >
-                                {renderSpriteImage(sprite, false)}
+                                <SpritePreviewImage sprite={sprite} isBackground={false} />
                                 {isSelected && (
                                     <div className="absolute -top-8 left-1/2 transform -translate-x-1/2 bg-black/70 text-white text-xs px-2 py-1 rounded whitespace-nowrap pointer-events-none z-[9999]">
                                         X: {sprite.x.toFixed(2)} Y: {sprite.y.toFixed(2)}
@@ -775,133 +948,35 @@ const SceneComposer: React.FC<SceneComposerProps> = ({ images, metadata, scene, 
             </div>
 
             {/* Bottom Panel */}
-            <div className="h-72 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 flex flex-row flex-shrink-0 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.1)] z-10">
-                
+            <div className="h-80 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 flex flex-row flex-shrink-0 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.1)] z-10">
+
                 {/* Properties Pane (Left) */}
                 <div className="flex-1 flex flex-col min-w-0">
                     <div className="flex-none p-2 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center bg-gray-50 dark:bg-gray-900/50">
                         <span className="font-bold text-xs ml-2 text-gray-700 dark:text-gray-300 uppercase tracking-wider">Properties</span>
+                        <span className="text-[9px] text-gray-400 dark:text-gray-500 ml-2" title="Undo/redo scene changes with Ctrl+Z / Ctrl+Y">Ctrl+Z to undo</span>
                         <div className="flex space-x-2">
-                            <button onClick={() => onSceneChange({ background: null, sprites: [] })} className="px-3 py-1 text-xs bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-300 rounded hover:bg-red-200 font-medium">Clear All</button>
+                            <button onClick={() => { saveUndo(); onSceneChange({ background: null, sprites: [] }); }} className="px-3 py-1 text-xs bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-300 rounded hover:bg-red-200 font-medium">Clear All</button>
                         </div>
                     </div>
-                    
+
                     {/* Properties Controls */}
-                    <div className="p-4 overflow-x-auto flex-1 flex items-start">
-                        {activeSprite ? (
-                            <div className="flex items-start space-x-4">
-                                <ControlGroup label="Transform">
-                                    <div className="flex space-x-1">
-                                        <button 
-                                            onClick={() => updateSprite(activeSprite.id, { flipH: !activeSprite.flipH })} 
-                                            className={`p-1.5 rounded ${activeSprite.flipH ? 'bg-indigo-600 text-white' : 'bg-gray-200 dark:bg-gray-600 text-gray-600 dark:text-gray-300'}`}
-                                            title="Flip Horizontal"
-                                        >
-                                            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" /></svg>
-                                        </button>
-                                        <button 
-                                            onClick={() => updateSprite(activeSprite.id, { flipV: !activeSprite.flipV })} 
-                                            className={`p-1.5 rounded ${activeSprite.flipV ? 'bg-indigo-600 text-white' : 'bg-gray-200 dark:bg-gray-600 text-gray-600 dark:text-gray-300'}`}
-                                            title="Flip Vertical"
-                                        >
-                                            <svg className="w-4 h-4 transform rotate-90" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" /></svg>
-                                        </button>
-                                    </div>
-                                </ControlGroup>
-
-                                <ControlGroup label="Scale & Rotation">
-                                    <div className="flex items-center space-x-3">
-                                        <div className="flex flex-col w-20">
-                                            <span className="text-[9px] text-gray-400 mb-0.5">Zoom</span>
-                                            <input 
-                                                type="number" step="0.1" value={activeSprite.zoom || 1} 
-                                                onChange={(e) => updateSprite(activeSprite.id, { zoom: Math.max(0.1, parseFloat(e.target.value)) })}
-                                                className="w-full text-xs p-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800"
-                                            />
-                                        </div>
-                                        <div className="flex flex-col w-20">
-                                            <span className="text-[9px] text-gray-400 mb-0.5">Angle</span>
-                                            <input 
-                                                type="number" value={activeSprite.rotation} 
-                                                onChange={(e) => updateSprite(activeSprite.id, { rotation: parseInt(e.target.value) })}
-                                                className="w-full text-xs p-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800"
-                                            />
-                                        </div>
-                                    </div>
-                                </ControlGroup>
-
-                                <ControlGroup label="Appearance">
-                                    <div className="flex items-center space-x-3">
-                                        <div className="flex flex-col w-28">
-                                            <div className="flex justify-between items-center mb-1">
-                                                <span className="text-[9px] text-gray-400">Opacity</span>
-                                                <input 
-                                                    type="number" 
-                                                    min="0" max="1" step="0.05" 
-                                                    value={activeSprite.alpha ?? 1} 
-                                                    onChange={(e) => updateSprite(activeSprite.id, { alpha: Math.min(1, Math.max(0, parseFloat(e.target.value))) })}
-                                                    className="w-12 text-[10px] p-0.5 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-right"
-                                                />
-                                            </div>
-                                            <input 
-                                                type="range" min="0" max="1" step="0.05" value={activeSprite.alpha ?? 1} 
-                                                onChange={(e) => updateSprite(activeSprite.id, { alpha: parseFloat(e.target.value) })}
-                                                className="h-1.5 bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-600 w-full"
-                                            />
-                                        </div>
-                                        <div className="flex flex-col w-28">
-                                            <div className="flex justify-between items-center mb-1">
-                                                <span className="text-[9px] text-gray-400">Blur (px)</span>
-                                                <input 
-                                                    type="number" 
-                                                    min="0" max="50" step="1" 
-                                                    value={activeSprite.blur ?? 0} 
-                                                    onChange={(e) => updateSprite(activeSprite.id, { blur: Math.max(0, parseInt(e.target.value) || 0) })}
-                                                    className="w-12 text-[10px] p-0.5 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-right"
-                                                />
-                                            </div>
-                                            <input 
-                                                type="range" min="0" max="50" step="1" value={activeSprite.blur ?? 0} 
-                                                onChange={(e) => updateSprite(activeSprite.id, { blur: parseInt(e.target.value) })}
-                                                className="h-1.5 bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-600 w-full"
-                                            />
-                                        </div>
-                                    </div>
-                                </ControlGroup>
-
-                                <div className="flex items-center space-x-2 border-l border-gray-200 dark:border-gray-700 pl-4 ml-auto">
-                                    {selectedSpriteId !== 'background' && (
-                                        <>
-                                            <button onClick={() => setSpriteAsBackground(activeSprite.id)} className="px-3 py-1.5 text-xs bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300 rounded hover:bg-gray-200 dark:hover:bg-gray-600 font-medium whitespace-nowrap">Make BG</button>
-                                            <button onClick={() => removeSprite(activeSprite.id)} className="px-3 py-1.5 text-xs bg-red-50 text-red-600 dark:bg-red-900/30 dark:text-red-400 rounded hover:bg-red-100 dark:hover:bg-red-900/50 font-medium">Delete</button>
-                                        </>
-                                    )}
-                                    {selectedSpriteId === 'background' && (
-                                        <button onClick={() => removeSprite('background')} className="px-3 py-1.5 text-xs bg-red-50 text-red-600 dark:bg-red-900/30 dark:text-red-400 rounded hover:bg-red-100 dark:hover:bg-red-900/50 font-medium">Clear BG</button>
-                                    )}
-                                </div>
-                            </div>
-                        ) : (
-                            <div className="w-full h-16 flex items-center justify-center border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-gray-800/50">
-                                <p className="text-sm text-gray-400 dark:text-gray-500 font-medium">Select a layer to edit properties</p>
-                            </div>
-                        )}
-                    </div>
-
-                    {/* Code Preview */}
-                    <div className="border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50 flex-shrink-0">
-                        <div className="flex justify-between items-center px-2 py-1">
-                            <span className="text-[10px] font-bold text-gray-400 uppercase">Code Preview</span>
-                            <CopyButton text={generatedCode} size="xs" />
-                        </div>
-                        <pre className="p-3 font-mono text-xs overflow-auto text-gray-600 dark:text-gray-400 select-text max-h-24 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700">
-                            {generatedCode}
-                        </pre>
+                    <div className="px-4 py-3 overflow-y-auto flex-1">
+                        <SceneSpriteProperties
+                            activeSprite={activeSprite}
+                            selectedSpriteId={selectedSpriteId}
+                            onUpdate={updateSprite}
+                            onRemove={removeSprite}
+                            onSetBackground={setSpriteAsBackground}
+                        />
                     </div>
                 </div>
 
-                {/* Layers Pane (Right) */}
-                <div className="w-64 bg-white dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700 flex flex-col flex-shrink-0">
+                {/* Right Column — Layers + Code Preview */}
+                <div className="flex-1 bg-white dark:bg-gray-800 border-l border-gray-200 dark:border-gray-700 flex flex-col min-w-0">
+
+                {/* Layers Pane */}
+                <div className="flex-1 flex flex-col min-h-0">
                     <div className="p-3 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50">
                         <h3 className="text-xs font-bold text-gray-500 uppercase tracking-wide">Layers (Foreground Top)</h3>
                     </div>
@@ -1041,6 +1116,19 @@ const SceneComposer: React.FC<SceneComposerProps> = ({ images, metadata, scene, 
                         )}
                     </div>
                 </div>
+
+                    {/* Code Preview */}
+                    <div className="flex-1 flex flex-col min-h-0 border-t border-gray-200 dark:border-gray-700">
+                        <div className="flex-none flex justify-between items-center px-2 py-1 bg-gray-50 dark:bg-gray-900/50 border-b border-gray-200 dark:border-gray-700">
+                            <span className="text-[10px] font-bold text-gray-400 uppercase">Code Preview</span>
+                            <CopyButton text={generatedCode} size="xs" />
+                        </div>
+                        <pre className="flex-1 p-3 font-mono text-xs overflow-auto text-gray-600 dark:text-gray-400 select-text bg-white dark:bg-gray-800 min-h-0">
+                            {generatedCode}
+                        </pre>
+                    </div>
+
+                </div>{/* end Right Column */}
 
             </div>
         </div>

--- a/components/SceneSpriteProperties.tsx
+++ b/components/SceneSpriteProperties.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import type { SceneSprite } from '../types';
+import MatrixPresetPopover from './MatrixPresetPopover';
 
 interface Props {
     activeSprite: SceneSprite | null;
@@ -102,6 +103,9 @@ const SceneSpriteProperties: React.FC<Props> = ({ activeSprite, selectedSpriteId
 
     const colorMode = activeSprite.colorMode ?? 'none';
     const saturation = activeSprite.saturation ?? 1.0;
+    const brightness = activeSprite.brightness ?? 0;
+    const contrast = activeSprite.contrast ?? 1.0;
+    const invert = activeSprite.invert ?? 0;
     const activeShader = activeSprite.activeShader ?? '';
     const shaderUniforms = activeSprite.shaderUniforms ?? {};
     const isCustomShader = activeShader !== '' && !PREDEFINED_SHADERS.includes(activeShader);
@@ -247,17 +251,22 @@ const SceneSpriteProperties: React.FC<Props> = ({ activeSprite, selectedSpriteId
             {/* Color Effects */}
             <ControlGroup label="Color Effects">
                 <div className="flex flex-col space-y-2">
-                    <div className="flex items-center space-x-2">
-                        <span className="text-[9px] text-gray-400 w-12 flex-shrink-0">Mode</span>
-                        <select
-                            value={colorMode}
-                            onChange={e => u({ colorMode: e.target.value as 'none' | 'tint' | 'colorize' })}
-                            className="text-xs p-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800"
-                        >
-                            <option value="none">None</option>
-                            <option value="tint">Tint</option>
-                            <option value="colorize">Colorize</option>
-                        </select>
+
+                    {/* Preset picker + mode selector */}
+                    <div className="flex items-center gap-2 flex-wrap">
+                        <MatrixPresetPopover onApply={u} />
+                        <div className="flex items-center gap-1.5">
+                            <span className="text-[9px] text-gray-400 flex-shrink-0">Mode</span>
+                            <select
+                                value={colorMode}
+                                onChange={e => u({ colorMode: e.target.value as 'none' | 'tint' | 'colorize' })}
+                                className="text-xs p-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800"
+                            >
+                                <option value="none">None</option>
+                                <option value="tint">Tint</option>
+                                <option value="colorize">Colorize</option>
+                            </select>
+                        </div>
                     </div>
 
                     {colorMode === 'tint' && (
@@ -291,6 +300,27 @@ const SceneSpriteProperties: React.FC<Props> = ({ activeSprite, selectedSpriteId
                             width="w-40"
                         />
                     )}
+
+                    {/* Brightness / Contrast / Invert — always visible */}
+                    <div className="flex items-start gap-3 pt-1.5 border-t border-gray-200 dark:border-gray-600 flex-wrap">
+                        <SliderRow
+                            label="Brightness" min={-1} max={1} step={0.05}
+                            value={brightness}
+                            onChange={v => u({ brightness: v })}
+                        />
+                        <SliderRow
+                            label="Contrast" min={0.1} max={3} step={0.05}
+                            value={contrast}
+                            onChange={v => u({ contrast: v })}
+                        />
+                        <SliderRow
+                            label="Invert" min={0} max={1} step={0.1}
+                            value={invert}
+                            onChange={v => u({ invert: v })}
+                            width="w-20"
+                        />
+                    </div>
+
                 </div>
             </ControlGroup>
 

--- a/components/SceneSpriteProperties.tsx
+++ b/components/SceneSpriteProperties.tsx
@@ -1,0 +1,396 @@
+import React, { useState } from 'react';
+import type { SceneSprite } from '../types';
+
+interface Props {
+    activeSprite: SceneSprite | null;
+    selectedSpriteId: string | null;
+    onUpdate: (id: string, updates: Partial<SceneSprite>) => void;
+    onRemove: (id: string) => void;
+    onSetBackground: (id: string) => void;
+}
+
+const SHADER_DEFS: Record<string, Array<{ name: string; label: string; min: number; max: number; step: number; default: number }>> = {
+    'renpy.blur': [
+        { name: 'u_renpy_blur_log2', label: 'Blur (log2)', min: 0, max: 5, step: 0.25, default: 1.0 },
+    ],
+    'renpy.dissolve': [
+        { name: 'u_renpy_dissolve', label: 'Dissolve', min: 0, max: 1, step: 0.05, default: 0.5 },
+    ],
+    'renpy.imagedissolve': [
+        { name: 'u_renpy_dissolve_offset',     label: 'Offset',     min: 0,  max: 1, step: 0.05, default: 0   },
+        { name: 'u_renpy_dissolve_multiplier', label: 'Multiplier', min: 0,  max: 2, step: 0.1,  default: 1.0 },
+    ],
+    'renpy.mask': [
+        { name: 'u_renpy_mask_multiplier', label: 'Multiplier', min: 0,  max: 2,  step: 0.1,  default: 1.0 },
+        { name: 'u_renpy_mask_offset',     label: 'Offset',     min: -1, max: 1,  step: 0.05, default: 0   },
+    ],
+    // renpy.pixelize is community-documented but not listed in official Ren'Py shader docs.
+    // Included because it is widely referenced and the IDE can approximate it in preview.
+    'renpy.pixelize': [
+        { name: 'u_amount', label: 'Pixel Size', min: 0.001, max: 0.1, step: 0.001, default: 0.01 },
+    ],
+};
+
+const PREDEFINED_SHADERS = Object.keys(SHADER_DEFS);
+
+const ControlGroup: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
+    <div className="flex flex-col space-y-1.5 p-2 bg-gray-50 dark:bg-gray-700/50 rounded border border-gray-200 dark:border-gray-600 flex-shrink-0">
+        <span className="text-[10px] font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wide">{label}</span>
+        <div className="flex items-start space-x-2">
+            {children}
+        </div>
+    </div>
+);
+
+const SliderRow: React.FC<{
+    label: string;
+    min: number; max: number; step: number;
+    value: number;
+    onChange: (v: number) => void;
+    width?: string;
+}> = ({ label, min, max, step, value, onChange, width = 'w-28' }) => (
+    <div className={`flex flex-col ${width}`}>
+        <div className="flex justify-between items-center mb-1">
+            <span className="text-[9px] text-gray-400">{label}</span>
+            <input
+                type="number" min={min} max={max} step={step} value={value}
+                onChange={e => onChange(Math.min(max, Math.max(min, parseFloat(e.target.value) || min)))}
+                className="w-12 text-[10px] p-0.5 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-right"
+            />
+        </div>
+        <input
+            type="range" min={min} max={max} step={step} value={value}
+            onChange={e => onChange(parseFloat(e.target.value))}
+            className="h-1.5 bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-600 w-full"
+        />
+    </div>
+);
+
+const ColorSwatch: React.FC<{ label: string; value: string; onChange: (hex: string) => void }> = ({ label, value, onChange }) => (
+    <div className="flex flex-col items-start space-y-1">
+        <span className="text-[9px] text-gray-400">{label}</span>
+        <div className="flex items-center space-x-1.5">
+            <input
+                type="color"
+                value={value || '#ffffff'}
+                onChange={e => onChange(e.target.value)}
+                className="w-7 h-7 rounded cursor-pointer border border-gray-300 dark:border-gray-600 p-0.5 bg-white dark:bg-gray-800"
+            />
+            <input
+                type="text"
+                value={value || '#ffffff'}
+                onChange={e => /^#[0-9a-fA-F]{0,6}$/.test(e.target.value) && onChange(e.target.value)}
+                className="w-16 text-[10px] p-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 font-mono"
+            />
+        </div>
+    </div>
+);
+
+const SceneSpriteProperties: React.FC<Props> = ({ activeSprite, selectedSpriteId, onUpdate, onRemove, onSetBackground }) => {
+    const [customShaderName, setCustomShaderName] = useState('');
+    const [customUniforms, setCustomUnforms] = useState<Array<{ key: string; value: number }>>([]);
+
+    if (!activeSprite) {
+        return (
+            <div className="w-full h-16 flex items-center justify-center border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-gray-800/50">
+                <p className="text-sm text-gray-400 dark:text-gray-500 font-medium">Select a layer to edit properties</p>
+            </div>
+        );
+    }
+
+    const u = (updates: Partial<SceneSprite>) => onUpdate(activeSprite.id, updates);
+
+    const colorMode = activeSprite.colorMode ?? 'none';
+    const saturation = activeSprite.saturation ?? 1.0;
+    const activeShader = activeSprite.activeShader ?? '';
+    const shaderUniforms = activeSprite.shaderUniforms ?? {};
+    const isCustomShader = activeShader !== '' && !PREDEFINED_SHADERS.includes(activeShader);
+
+    const handleShaderChange = (shader: string) => {
+        if (shader === '') {
+            u({ activeShader: '', shaderUniforms: {} });
+            return;
+        }
+        if (shader === '__custom__') {
+            u({ activeShader: customShaderName || '', shaderUniforms: {} });
+            return;
+        }
+        const defaults: Record<string, number> = {};
+        (SHADER_DEFS[shader] ?? []).forEach(d => { defaults[d.name] = d.default; });
+        u({ activeShader: shader, shaderUniforms: defaults });
+    };
+
+    const handleUniformChange = (name: string, value: number) => {
+        u({ shaderUniforms: { ...shaderUniforms, [name]: value } });
+    };
+
+    const addCustomUniform = () => {
+        setCustomUnforms(prev => [...prev, { key: `u_param${prev.length + 1}`, value: 1.0 }]);
+    };
+
+    const updateCustomUniformKey = (index: number, key: string) => {
+        setCustomUnforms(prev => {
+            const next = [...prev];
+            const oldKey = next[index].key;
+            next[index] = { ...next[index], key };
+            const newUniforms = { ...shaderUniforms };
+            delete newUniforms[oldKey];
+            newUniforms[key] = next[index].value;
+            u({ shaderUniforms: newUniforms });
+            return next;
+        });
+    };
+
+    const updateCustomUniformValue = (index: number, value: number) => {
+        setCustomUnforms(prev => {
+            const next = [...prev];
+            next[index] = { ...next[index], value };
+            u({ shaderUniforms: { ...shaderUniforms, [next[index].key]: value } });
+            return next;
+        });
+    };
+
+    const removeCustomUniform = (index: number) => {
+        setCustomUnforms(prev => {
+            const next = [...prev];
+            const key = next[index].key;
+            next.splice(index, 1);
+            const newUniforms = { ...shaderUniforms };
+            delete newUniforms[key];
+            u({ shaderUniforms: newUniforms });
+            return next;
+        });
+    };
+
+    return (
+        <div className="flex flex-col gap-3 w-full">
+
+        {/* Row 1 — geometric controls */}
+        <div className="flex flex-wrap items-start gap-3">
+
+            {/* Transform */}
+            <ControlGroup label="Transform">
+                <div className="flex space-x-1">
+                    <button
+                        onClick={() => u({ flipH: !activeSprite.flipH })}
+                        className={`p-1.5 rounded ${activeSprite.flipH ? 'bg-indigo-600 text-white' : 'bg-gray-200 dark:bg-gray-600 text-gray-600 dark:text-gray-300'}`}
+                        title="Flip Horizontal"
+                    >
+                        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" /></svg>
+                    </button>
+                    <button
+                        onClick={() => u({ flipV: !activeSprite.flipV })}
+                        className={`p-1.5 rounded ${activeSprite.flipV ? 'bg-indigo-600 text-white' : 'bg-gray-200 dark:bg-gray-600 text-gray-600 dark:text-gray-300'}`}
+                        title="Flip Vertical"
+                    >
+                        <svg className="w-4 h-4 transform rotate-90" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" /></svg>
+                    </button>
+                </div>
+            </ControlGroup>
+
+            {/* Scale & Rotation */}
+            <ControlGroup label="Scale & Rotation">
+                <div className="flex items-center space-x-3">
+                    <div className="flex flex-col w-20">
+                        <span className="text-[9px] text-gray-400 mb-0.5">Zoom</span>
+                        <input
+                            type="number" step="0.1" value={activeSprite.zoom || 1}
+                            onChange={e => u({ zoom: Math.max(0.1, parseFloat(e.target.value)) })}
+                            className="w-full text-xs p-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800"
+                        />
+                    </div>
+                    <div className="flex flex-col w-20">
+                        <span className="text-[9px] text-gray-400 mb-0.5">Angle</span>
+                        <input
+                            type="number" value={activeSprite.rotation}
+                            onChange={e => u({ rotation: parseInt(e.target.value) })}
+                            className="w-full text-xs p-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800"
+                        />
+                    </div>
+                </div>
+            </ControlGroup>
+
+            {/* Appearance */}
+            <ControlGroup label="Appearance">
+                <div className="flex items-center space-x-3">
+                    <SliderRow
+                        label="Opacity" min={0} max={1} step={0.05}
+                        value={activeSprite.alpha ?? 1}
+                        onChange={v => u({ alpha: v })}
+                    />
+                    <SliderRow
+                        label="Blur (px)" min={0} max={50} step={1}
+                        value={activeSprite.blur ?? 0}
+                        onChange={v => u({ blur: v })}
+                    />
+                </div>
+            </ControlGroup>
+
+            {/* Actions */}
+            <div className="flex items-center space-x-2 border-l border-gray-200 dark:border-gray-700 pl-4 ml-auto flex-shrink-0 self-center">
+                {selectedSpriteId !== 'background' && (
+                    <>
+                        <button onClick={() => onSetBackground(activeSprite.id)} className="px-3 py-1.5 text-xs bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300 rounded hover:bg-gray-200 dark:hover:bg-gray-600 font-medium whitespace-nowrap">Make BG</button>
+                        <button onClick={() => onRemove(activeSprite.id)} className="px-3 py-1.5 text-xs bg-red-50 text-red-600 dark:bg-red-900/30 dark:text-red-400 rounded hover:bg-red-100 dark:hover:bg-red-900/50 font-medium">Delete</button>
+                    </>
+                )}
+                {selectedSpriteId === 'background' && (
+                    <button onClick={() => onRemove('background')} className="px-3 py-1.5 text-xs bg-red-50 text-red-600 dark:bg-red-900/30 dark:text-red-400 rounded hover:bg-red-100 dark:hover:bg-red-900/50 font-medium">Clear BG</button>
+                )}
+            </div>
+
+        </div>{/* end Row 1 */}
+
+        {/* Row 2 — color & shader effects */}
+        <div className="flex flex-wrap items-start gap-3">
+
+            {/* Color Effects */}
+            <ControlGroup label="Color Effects">
+                <div className="flex flex-col space-y-2">
+                    <div className="flex items-center space-x-2">
+                        <span className="text-[9px] text-gray-400 w-12 flex-shrink-0">Mode</span>
+                        <select
+                            value={colorMode}
+                            onChange={e => u({ colorMode: e.target.value as 'none' | 'tint' | 'colorize' })}
+                            className="text-xs p-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800"
+                        >
+                            <option value="none">None</option>
+                            <option value="tint">Tint</option>
+                            <option value="colorize">Colorize</option>
+                        </select>
+                    </div>
+
+                    {colorMode === 'tint' && (
+                        <ColorSwatch
+                            label="Tint Color"
+                            value={activeSprite.tintColor ?? '#ffffff'}
+                            onChange={hex => u({ tintColor: hex })}
+                        />
+                    )}
+
+                    {colorMode === 'colorize' && (
+                        <div className="flex space-x-3">
+                            <ColorSwatch
+                                label="Shadows"
+                                value={activeSprite.colorizeBlack ?? '#000000'}
+                                onChange={hex => u({ colorizeBlack: hex })}
+                            />
+                            <ColorSwatch
+                                label="Highlights"
+                                value={activeSprite.colorizeWhite ?? '#ffffff'}
+                                onChange={hex => u({ colorizeWhite: hex })}
+                            />
+                        </div>
+                    )}
+
+                    {colorMode !== 'none' && (
+                        <SliderRow
+                            label="Saturation" min={0} max={2} step={0.05}
+                            value={saturation}
+                            onChange={v => u({ saturation: v })}
+                            width="w-40"
+                        />
+                    )}
+                </div>
+            </ControlGroup>
+
+            {/* Shaders */}
+            <ControlGroup label="Shaders">
+                <div className="flex flex-col space-y-2">
+                    <div className="flex items-center space-x-2">
+                        <span className="text-[9px] text-gray-400 w-12 flex-shrink-0">Shader</span>
+                        <select
+                            value={isCustomShader ? '__custom__' : activeShader}
+                            onChange={e => handleShaderChange(e.target.value)}
+                            className="text-xs p-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800"
+                        >
+                            <option value="">None</option>
+                            {PREDEFINED_SHADERS.map(s => <option key={s} value={s}>{s}</option>)}
+                            <option value="__custom__">Custom…</option>
+                        </select>
+                    </div>
+
+                    {/* No-preview badge for shaders with no CSS approximation */}
+                    {(activeShader === 'renpy.dissolve' || activeShader === 'renpy.imagedissolve' || activeShader === 'renpy.mask') && (
+                        <div className="flex items-center space-x-1.5 px-2 py-1 rounded bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700">
+                            <svg className="w-3 h-3 text-amber-500 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 100 20A10 10 0 0012 2z" />
+                            </svg>
+                            <span className="text-[9px] text-amber-600 dark:text-amber-400">No IDE preview — effect appears in Ren'Py</span>
+                        </div>
+                    )}
+
+                    {/* Unofficial shader note */}
+                    {activeShader === 'renpy.pixelize' && (
+                        <div className="flex items-center space-x-1.5 px-2 py-1 rounded bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700">
+                            <svg className="w-3 h-3 text-blue-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 100 20A10 10 0 0012 2z" />
+                            </svg>
+                            <span className="text-[9px] text-blue-500 dark:text-blue-400">Community shader — not in official Ren'Py docs</span>
+                        </div>
+                    )}
+
+                    {/* Predefined shader uniforms */}
+                    {activeShader && !isCustomShader && (SHADER_DEFS[activeShader] ?? []).map(def => (
+                        <SliderRow
+                            key={def.name}
+                            label={def.label}
+                            min={def.min} max={def.max} step={def.step}
+                            value={shaderUniforms[def.name] ?? def.default}
+                            onChange={v => handleUniformChange(def.name, v)}
+                            width="w-40"
+                        />
+                    ))}
+
+                    {/* Custom shader name + uniforms */}
+                    {isCustomShader && (
+                        <div className="flex flex-col space-y-1.5">
+                            <div className="flex items-center space-x-1.5">
+                                <span className="text-[9px] text-gray-400 w-12 flex-shrink-0">Name</span>
+                                <input
+                                    type="text"
+                                    value={customShaderName || activeShader}
+                                    placeholder="my.shader"
+                                    onChange={e => {
+                                        setCustomShaderName(e.target.value);
+                                        u({ activeShader: e.target.value });
+                                    }}
+                                    className="text-xs p-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 w-32"
+                                />
+                            </div>
+                            {customUniforms.map((cu, i) => (
+                                <div key={i} className="flex items-center space-x-1.5">
+                                    <input
+                                        type="text"
+                                        value={cu.key}
+                                        onChange={e => updateCustomUniformKey(i, e.target.value)}
+                                        className="text-[10px] p-0.5 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 w-24 font-mono"
+                                    />
+                                    <input
+                                        type="number" step="0.1" value={cu.value}
+                                        onChange={e => updateCustomUniformValue(i, parseFloat(e.target.value) || 0)}
+                                        className="text-[10px] p-0.5 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 w-14 text-right"
+                                    />
+                                    <button
+                                        onClick={() => removeCustomUniform(i)}
+                                        className="text-red-400 hover:text-red-600 text-xs px-1"
+                                        title="Remove uniform"
+                                    >✕</button>
+                                </div>
+                            ))}
+                            <button
+                                onClick={addCustomUniform}
+                                className="text-[10px] text-indigo-500 hover:text-indigo-700 text-left"
+                            >+ Add uniform</button>
+                        </div>
+                    )}
+                </div>
+            </ControlGroup>
+
+        </div>{/* end Row 2 */}
+
+        </div>
+    );
+};
+
+export default SceneSpriteProperties;

--- a/components/Toolbar.tsx
+++ b/components/Toolbar.tsx
@@ -35,6 +35,8 @@ interface ToolbarProps {
   isRenpyPathValid: boolean;
   draftingMode: boolean;
   onToggleDraftingMode: (enabled: boolean) => void;
+  /** Hide undo/redo buttons when a composer tab owns its own undo stack */
+  hideUndoRedo?: boolean;
 }
 
 const ToolbarButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement> & {
@@ -81,6 +83,7 @@ const Toolbar: React.FC<ToolbarProps> = ({
   isRenpyPathValid,
   draftingMode,
   onToggleDraftingMode,
+  hideUndoRedo = false,
 }) => {
 
   const totalUnsavedCount = useMemo(() => {
@@ -135,13 +138,15 @@ const Toolbar: React.FC<ToolbarProps> = ({
 
       {/* ── Absolutely centered: editing tools + canvas switcher ── */}
       <div className="absolute left-1/2 -translate-x-1/2 flex items-center gap-3">
-        <ToolbarButton onClick={undo} disabled={!canUndo} title="Undo (Ctrl+Z)" aria-label="Undo">
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M9.707 16.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l4.293 4.293a1 1 0 010 1.414z" clipRule="evenodd" /></svg>
-        </ToolbarButton>
-        <ToolbarButton onClick={redo} disabled={!canRedo} title="Redo (Ctrl+Y)" aria-label="Redo">
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clipRule="evenodd" /></svg>
-        </ToolbarButton>
-        <div className="h-6 w-px bg-primary shrink-0" />
+        {!hideUndoRedo && (<>
+          <ToolbarButton onClick={undo} disabled={!canUndo} title="Undo (Ctrl+Z)" aria-label="Undo">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M9.707 16.707a1 1 0 01-1.414 0l-6-6a1 1 0 010-1.414l6-6a1 1 0 011.414 1.414L5.414 9H17a1 1 0 110 2H5.414l4.293 4.293a1 1 0 010 1.414z" clipRule="evenodd" /></svg>
+          </ToolbarButton>
+          <ToolbarButton onClick={redo} disabled={!canRedo} title="Redo (Ctrl+Y)" aria-label="Redo">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clipRule="evenodd" /></svg>
+          </ToolbarButton>
+          <div className="h-6 w-px bg-primary shrink-0" />
+        </>)}
 
         <ToolbarButton onClick={addBlock} title="New Scene (N)" variant="primary" data-tutorial="new-scene-button">
           <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clipRule="evenodd" /></svg>

--- a/types.ts
+++ b/types.ts
@@ -742,6 +742,13 @@ export interface SceneSprite {
   blur: number;
   visible?: boolean;
   locked?: boolean;
+  colorMode?: 'none' | 'tint' | 'colorize';
+  tintColor?: string;
+  colorizeBlack?: string;
+  colorizeWhite?: string;
+  saturation?: number;
+  activeShader?: string;
+  shaderUniforms?: Record<string, number>;
 }
 
 /**

--- a/types.ts
+++ b/types.ts
@@ -747,6 +747,9 @@ export interface SceneSprite {
   colorizeBlack?: string;
   colorizeWhite?: string;
   saturation?: number;
+  brightness?: number;
+  contrast?: number;
+  invert?: number;
   activeShader?: string;
   shaderUniforms?: Record<string, number>;
 }


### PR DESCRIPTION
## Summary

- Implements the Visual Effects & Shader Suite from issue #119 across all 5 phases: Effects Panel, Color Matrix, Shaders, Live Preview, and Code Generation
- Adds a **matrixcolor preset popover** with 20 named presets across 5 narrative categories (Environmental, Flashbacks, Character State, Horror, Special Effects) — each shown with a color swatch for fast visual selection
- Adds **Brightness**, **Contrast**, and **Invert** as first-class sprite properties with sliders, CSS live preview approximation, and full Ren'Py code generation (`BrightnessMatrix`, `ContrastMatrix`, `InvertMatrix`)

## What's included

- `components/MatrixPresetPopover.tsx` — new swatch popover component with 20 presets; portal-based fixed positioning, outside-click dismissal, full field reset on preset apply to prevent stacking
- `components/SceneSpriteProperties.tsx` — "Presets" button inline with Mode selector; Brightness / Contrast / Invert sliders always visible in the Color Effects group
- `components/SceneComposer.tsx` — updated `spriteVisualFilter` (CSS preview) and `spriteEffectCode` (Ren'Py output) to handle all new matrix operations
- `types.ts` — `brightness?: number`, `contrast?: number`, `invert?: number` added to `SceneSprite`

## Not included (deferred)

- Timeline/animation controls — flagged in the issue as better addressed in the ATL Builder tab

## Test plan

- [ ] Select a sprite in Scene Composer → open Presets popover → confirm all 5 categories and 20 presets are listed with swatches
- [ ] Apply a preset (e.g. Night) → confirm canvas preview updates and generated code shows the correct `matrixcolor` expression
- [ ] Apply a colorize preset (e.g. Blood Red) → confirm Shadows/Highlights color pickers update in the panel
- [ ] Manually adjust Brightness/Contrast/Invert sliders → confirm live preview and code output update independently
- [ ] Apply preset, then change Mode dropdown → confirm color controls update correctly
- [ ] Verify generated code format matches Ren'Py ATL: `matrixcolor TintMatrix("#444466") * BrightnessMatrix(-0.10)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)