### PR TITLE
ci: run lint and unit tests on all three platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,12 @@ on:
 
 jobs:
   test:
-    name: Test & Lint
-    runs-on: ubuntu-latest
+    name: Test & Lint on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: Check out Git repository


### PR DESCRIPTION
## Summary
- Extends the `test` job in `build.yml` from a single `ubuntu-latest` runner to a matrix of `ubuntu-latest`, `windows-latest`, and `macos-latest`
- Uses `fail-fast: false` so all three platforms report independently — a Windows failure doesn't cancel the macOS run
- The `build` job still `needs: test`, so a cross-platform test failure blocks packaging

## Why
Part of Issue #92. Until now, unit tests only ran on Linux. This gives us signal on every push/PR that the Vitest suite passes on all three OSes, catching any path-separator, line-ending, or glob quirks before they reach a release build.

## Test plan
- [ ] Confirm all three `Test & Lint on <os>` jobs appear in the Actions run for this PR
- [ ] Confirm the existing `build` matrix jobs still trigger only after all three test jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)