### PR TITLE
[codex] fix translation dashboard modal and file breakdown counts

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2833,7 +2833,11 @@ const App: React.FC = () => {
         addToast(`Translation files generated for "${language}"`, 'success');
         await handleRefreshProject();
       } else {
-        addToast(`Failed to generate translations: ${result.error || 'Unknown error'}`, 'error');
+        const detail = result.error || 'Unknown error';
+        console.error('Generate translations failed:\n', detail);
+        // Show first meaningful line in the toast, full output is in the console
+        const firstLine = detail.split('\n').find(l => l.trim().length > 0) || detail;
+        addToast(`Translation generation failed: ${firstLine}`, 'error');
       }
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/App.tsx
+++ b/App.tsx
@@ -247,6 +247,7 @@ const App: React.FC = () => {
     lastProjectDir: '',
   });
   const [isRenpyPathValid, setIsRenpyPathValid] = useState(false);
+  const [isGeneratingTranslations, setIsGeneratingTranslations] = useState(false);
   const [projectSettings, updateProjectSettings] = useImmer<Omit<ProjectSettings, 'openTabs' | 'activeTabId' | 'stickyNotes' | 'characterProfiles' | 'punchlistMetadata' | 'diagnosticsTasks' | 'ignoredDiagnostics' | 'sceneCompositions' | 'sceneNames' | 'scannedImagePaths' | 'scannedAudioPaths'>>({
     draftingMode: false,
     storyCanvasLayoutMode: 'flow-lr',
@@ -2823,6 +2824,21 @@ const App: React.FC = () => {
       }
   }, [projectRootPath, addToast, setBlocks, setFileSystemTree, setImages, setAudios]);
 
+  const handleGenerateTranslations = useCallback(async (language: string) => {
+    if (!appSettings.renpyPath || !projectRootPath) return;
+    setIsGeneratingTranslations(true);
+    try {
+      await window.electronAPI!.generateTranslations(appSettings.renpyPath, projectRootPath, language);
+      addToast(`Translation files generated for "${language}"`, 'success');
+      await handleRefreshProject();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      addToast(`Failed to generate translations: ${msg}`, 'error');
+    } finally {
+      setIsGeneratingTranslations(false);
+    }
+  }, [appSettings.renpyPath, projectRootPath, addToast, handleRefreshProject]);
+
   const handleNewProjectRequest = useCallback(() => {
     const hasUnsaved = dirtyBlockIds.size > 0 || dirtyEditors.size > 0 || hasUnsavedSettings;
     
@@ -4410,6 +4426,9 @@ const App: React.FC = () => {
         translationData={analysisResult.translationData}
         blocks={blocks}
         onOpenBlock={handleOpenEditor}
+        onGenerateTranslations={handleGenerateTranslations}
+        isGenerating={isGeneratingTranslations}
+        isRenpyPathValid={isRenpyPathValid}
       />;
     }
     if (tab.type === 'editor' && tab.blockId) {

--- a/App.tsx
+++ b/App.tsx
@@ -2828,9 +2828,13 @@ const App: React.FC = () => {
     if (!appSettings.renpyPath || !projectRootPath) return;
     setIsGeneratingTranslations(true);
     try {
-      await window.electronAPI!.generateTranslations(appSettings.renpyPath, projectRootPath, language);
-      addToast(`Translation files generated for "${language}"`, 'success');
-      await handleRefreshProject();
+      const result = await window.electronAPI!.generateTranslations(appSettings.renpyPath, projectRootPath, language);
+      if (result.success) {
+        addToast(`Translation files generated for "${language}"`, 'success');
+        await handleRefreshProject();
+      } else {
+        addToast(`Failed to generate translations: ${result.error || 'Unknown error'}`, 'error');
+      }
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       addToast(`Failed to generate translations: ${msg}`, 'error');

--- a/App.tsx
+++ b/App.tsx
@@ -37,6 +37,7 @@ import { MenuConstructorModal } from './components/MenuConstructorModal';
 import FirstRunTutorial from './components/FirstRunTutorial';
 import { SearchProvider } from './contexts/SearchContext';
 import StatsView from './components/StatsView';
+import TranslationDashboard from './components/TranslationDashboard';
 import GoToLabelModal, { GoToLabelItem } from './components/GoToLabelModal';
 import { useRenpyAnalysis, performRouteAnalysis } from './hooks/useRenpyAnalysis';
 import { useHistory } from './hooks/useHistory';
@@ -1582,7 +1583,7 @@ const App: React.FC = () => {
   }, [isInitialAnalysisPending, isAnalysisPending, routeAnalysisResult.labelNodes]);
 
   // --- Tab Management Helpers ---
-  const handleOpenStaticTab = useCallback((type: 'canvas' | 'route-canvas' | 'choice-canvas' | 'diagnostics' | 'stats') => {
+  const handleOpenStaticTab = useCallback((type: 'canvas' | 'route-canvas' | 'choice-canvas' | 'diagnostics' | 'stats' | 'translations') => {
         const id = type;
         // If already open in primary, activate it there
         if (openTabs.find(t => t.id === id)) {
@@ -1939,7 +1940,7 @@ const App: React.FC = () => {
                   if (tab.type === 'markdown' && tab.filePath) {
                       return true; // File existence checked on tab render
                   }
-                  return tab.type === 'canvas' || tab.type === 'route-canvas' || tab.type === 'choice-canvas' || tab.type === 'punchlist' || tab.type === 'diagnostics' || tab.type === 'stats';
+                  return tab.type === 'canvas' || tab.type === 'route-canvas' || tab.type === 'choice-canvas' || tab.type === 'punchlist' || tab.type === 'diagnostics' || tab.type === 'stats' || tab.type === 'translations';
               });
 
               const rehydratedTabs = validTabs.map(tab => {
@@ -1974,7 +1975,7 @@ const App: React.FC = () => {
                   if (tab.type === 'audio' && tab.filePath) return audioMap.has(tab.filePath);
                   if (tab.type === 'character' && tab.characterTag) return true;
                   if (tab.type === 'markdown' && tab.filePath) return true;
-                  return tab.type === 'canvas' || tab.type === 'route-canvas' || tab.type === 'choice-canvas' || tab.type === 'punchlist' || tab.type === 'diagnostics' || tab.type === 'stats' || tab.type === 'scene-composer';
+                  return tab.type === 'canvas' || tab.type === 'route-canvas' || tab.type === 'choice-canvas' || tab.type === 'punchlist' || tab.type === 'diagnostics' || tab.type === 'stats' || tab.type === 'translations' || tab.type === 'scene-composer';
               });
               setSplitLayout(validSecondary.length > 0 ? savedSplitLayout : 'none');
               setSplitPrimarySize(projectData.settings.splitPrimarySize ?? 600);
@@ -3835,7 +3836,7 @@ const App: React.FC = () => {
             if (data.command === 'save-all') handleSaveAll();
             if (data.command === 'run-project' && projectRootPath) window.electronAPI?.runGame(appSettings.renpyPath, projectRootPath);
             if (data.command === 'stop-project') window.electronAPI?.stopGame();
-            if (data.command === 'open-static-tab' && data.type) handleOpenStaticTab(data.type as 'canvas' | 'route-canvas' | 'diagnostics');
+            if (data.command === 'open-static-tab' && data.type) handleOpenStaticTab(data.type as 'canvas' | 'route-canvas' | 'diagnostics' | 'translations');
             if (data.command === 'toggle-search') handleToggleSearch();
             if (data.command === 'open-settings') setSettingsModalOpen(true);
             if (data.command === 'open-shortcuts') setShortcutsModalOpen(true);
@@ -4311,6 +4312,7 @@ const App: React.FC = () => {
     if (tab.id === 'choice-canvas') return 'Choices Canvas';
     if (tab.id === 'diagnostics' || tab.id === 'punchlist') return 'Diagnostics';
     if (tab.id === 'stats') return 'Stats';
+    if (tab.id === 'translations') return 'Translations';
     if (tab.type === 'scene-composer') return sceneNames[tab.sceneId!] || 'Scene';
     if (tab.type === 'imagemap-composer') return imagemapCompositions[tab.imagemapId!]?.screenName || 'ImageMap';
     if (tab.type === 'screen-layout-composer') return screenLayoutCompositions[tab.layoutId!]?.screenName || 'Screen Layout';
@@ -4401,6 +4403,13 @@ const App: React.FC = () => {
         diagnosticsErrorCount={diagnosticsResult.errorCount}
         onOpenDiagnostics={() => handleOpenStaticTab('diagnostics')}
         performanceMetrics={perfSnapshot}
+      />;
+    }
+    if (tab.id === 'translations') {
+      return <TranslationDashboard
+        translationData={analysisResult.translationData}
+        blocks={blocks}
+        onOpenBlock={handleOpenEditor}
       />;
     }
     if (tab.type === 'editor' && tab.blockId) {
@@ -4652,7 +4661,7 @@ const App: React.FC = () => {
         handleTidyUp={handleActiveCanvasTidyUp}
         handleSave={handleSaveAll}
         onOpenSettings={() => setSettingsModalOpen(true)}
-        onOpenStaticTab={handleOpenStaticTab as (type: 'canvas' | 'route-canvas' | 'choice-canvas' | 'stats' | 'diagnostics') => void}
+        onOpenStaticTab={handleOpenStaticTab as (type: 'canvas' | 'route-canvas' | 'choice-canvas' | 'stats' | 'diagnostics' | 'translations') => void}
         diagnosticsErrorCount={diagnosticsResult.errorCount}
         onAddStickyNote={activeCanvasOnAddStickyNote}
         isGameRunning={isGameRunning}

--- a/components/Toolbar.tsx
+++ b/components/Toolbar.tsx
@@ -25,7 +25,7 @@ interface ToolbarProps {
   handleTidyUp: () => void;
   handleSave: () => void;
   onOpenSettings: () => void;
-  onOpenStaticTab: (type: 'canvas' | 'route-canvas' | 'choice-canvas' | 'stats' | 'diagnostics') => void;
+  onOpenStaticTab: (type: 'canvas' | 'route-canvas' | 'choice-canvas' | 'stats' | 'diagnostics' | 'translations') => void;
   diagnosticsErrorCount: number;
   /** null = disabled (no canvas active that supports notes) */
   onAddStickyNote: (() => void) | null;
@@ -191,6 +191,12 @@ const Toolbar: React.FC<ToolbarProps> = ({
         <ToolbarButton onClick={() => onOpenStaticTab('stats')} title="Script Statistics" aria-label="Script Statistics">
           <svg xmlns="http://www.w3.org/2000/svg" className="h-8 w-8" viewBox="0 0 20 20" fill="currentColor">
             <path d="M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zm6-4a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zm6-3a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z" />
+          </svg>
+        </ToolbarButton>
+
+        <ToolbarButton onClick={() => onOpenStaticTab('translations')} title="Translation Dashboard" aria-label="Translation Dashboard">
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-8 w-8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 21l5.25-11.25L21 21m-9-3h7.5M3 5.621a48.474 48.474 0 016-.371m0 0c1.12 0 2.233.038 3.334.114M9 5.25V3m3.334 2.364C11.176 10.658 7.69 15.08 3 17.502m9.334-12.138c.896.061 1.785.147 2.666.257m-4.589 8.495A18.023 18.023 0 0114.999 17" />
           </svg>
         </ToolbarButton>
 

--- a/components/TranslationDashboard.tsx
+++ b/components/TranslationDashboard.tsx
@@ -4,7 +4,8 @@
  * detected languages. Three sections: language overview cards, file breakdown
  * table, and a virtual string-level view.
  */
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import type { TranslationAnalysisResult, LanguageCoverage, TranslationFileBreakdown, Block } from '../types';
 import { useVirtualList } from '../hooks/useVirtualList';
 
@@ -48,12 +49,14 @@ type SortDir = 'asc' | 'desc';
 function sortFileBreakdown(rows: TranslationFileBreakdown[], key: FileSortKey, dir: SortDir): TranslationFileBreakdown[] {
   const sorted = [...rows];
   const mult = dir === 'asc' ? 1 : -1;
+  const getEffectiveTranslated = (row: TranslationFileBreakdown) => row.translatedCount - row.staleCount;
+  const getEffectiveUntranslated = (row: TranslationFileBreakdown) => row.totalStrings - getEffectiveTranslated(row);
   sorted.sort((a, b) => {
     switch (key) {
       case 'file': return mult * a.sourceFilePath.localeCompare(b.sourceFilePath);
       case 'total': return mult * (a.totalStrings - b.totalStrings);
-      case 'translated': return mult * (a.translatedCount - b.translatedCount);
-      case 'untranslated': return mult * ((a.totalStrings - a.translatedCount) - (b.totalStrings - b.translatedCount));
+      case 'translated': return mult * (getEffectiveTranslated(a) - getEffectiveTranslated(b));
+      case 'untranslated': return mult * (getEffectiveUntranslated(a) - getEffectiveUntranslated(b));
       case 'stale': return mult * (a.staleCount - b.staleCount);
       case 'completion': return mult * (a.completionPercent - b.completionPercent);
     }
@@ -85,6 +88,25 @@ const TranslationDashboard: React.FC<TranslationDashboardProps> = ({ translation
 
   const isLanguageValid = LANGUAGE_PATTERN.test(languageInput);
 
+  useEffect(() => {
+    if (!showGenerateForm || typeof document === 'undefined') return;
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setShowGenerateForm(false);
+        setLanguageInput('');
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.body.style.overflow = prevOverflow;
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [showGenerateForm]);
+
   const handleGenerate = useCallback(async () => {
     if (!isLanguageValid) return;
     await onGenerateTranslations(languageInput);
@@ -109,38 +131,79 @@ const TranslationDashboard: React.FC<TranslationDashboardProps> = ({ translation
     </button>
   );
 
-  const generateForm = showGenerateForm ? (
-    <div className="flex items-center gap-2 mt-2" data-testid="generate-form">
-      <input
-        type="text"
-        placeholder='e.g. "french", "japanese"'
-        value={languageInput}
-        onChange={e => setLanguageInput(e.target.value.toLowerCase())}
-        onKeyDown={e => { if (e.key === 'Enter') handleGenerate(); if (e.key === 'Escape') setShowGenerateForm(false); }}
-        className="px-2 py-1 text-xs bg-secondary border border-primary rounded focus:outline-none focus:ring-1 focus:ring-indigo-400 text-primary placeholder:text-secondary w-48"
-        data-testid="language-input"
-        autoFocus
-      />
-      <button
-        onClick={handleGenerate}
-        disabled={!isLanguageValid || isGenerating}
-        className="px-3 py-1 text-xs font-medium rounded-md bg-indigo-500 text-white hover:bg-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-        data-testid="confirm-generate-btn"
-      >
-        Generate
-      </button>
-      <button
-        onClick={() => { setShowGenerateForm(false); setLanguageInput(''); }}
-        className="px-3 py-1 text-xs font-medium rounded-md bg-secondary text-secondary hover:bg-tertiary border border-primary transition-colors"
-        data-testid="cancel-generate-btn"
-      >
-        Cancel
-      </button>
-      {languageInput && !isLanguageValid && (
-        <span className="text-xs text-red-500" data-testid="language-validation-error">Lowercase letters, numbers, underscores only. Must start with a letter.</span>
-      )}
-    </div>
-  ) : null;
+  const generateModal = showGenerateForm && typeof document !== 'undefined'
+    ? createPortal(
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center px-4 py-6 bg-black/50 backdrop-blur-sm"
+          onMouseDown={() => {
+            setShowGenerateForm(false);
+            setLanguageInput('');
+          }}
+          data-testid="generate-modal"
+        >
+          <div
+            className="w-full max-w-md rounded-xl border border-primary bg-secondary shadow-2xl p-5"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="generate-translation-title"
+            data-testid="generate-form"
+            onMouseDown={e => e.stopPropagation()}
+          >
+            <div className="flex items-start justify-between gap-4 mb-4">
+              <div>
+                <h3 id="generate-translation-title" className="text-base font-semibold text-primary">
+                  Generate Translations
+                </h3>
+                <p className="text-xs text-secondary mt-1">
+                  Enter the language code Ren'Py should generate under <code className="px-1 py-0.5 bg-tertiary rounded">game/tl/</code>.
+                </p>
+              </div>
+              <button
+                onClick={() => { setShowGenerateForm(false); setLanguageInput(''); }}
+                className="text-secondary hover:text-primary text-lg leading-none"
+                aria-label="Close dialog"
+              >
+                ×
+              </button>
+            </div>
+
+            <div className="flex flex-col gap-3">
+              <input
+                type="text"
+                placeholder='e.g. "french", "japanese"'
+                value={languageInput}
+                onChange={e => setLanguageInput(e.target.value.toLowerCase())}
+                onKeyDown={e => { if (e.key === 'Enter') handleGenerate(); }}
+                className="px-3 py-2 text-sm bg-primary border border-primary rounded focus:outline-none focus:ring-1 focus:ring-indigo-400 text-primary placeholder:text-secondary"
+                data-testid="language-input"
+                autoFocus
+              />
+              {languageInput && !isLanguageValid && (
+                <span className="text-xs text-red-500" data-testid="language-validation-error">Lowercase letters, numbers, underscores only. Must start with a letter.</span>
+              )}
+              <div className="flex justify-end gap-2 pt-1">
+                <button
+                  onClick={() => { setShowGenerateForm(false); setLanguageInput(''); }}
+                  className="px-3 py-1.5 text-xs font-medium rounded-md bg-secondary text-secondary hover:bg-tertiary border border-primary transition-colors"
+                  data-testid="cancel-generate-btn"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleGenerate}
+                  disabled={!isLanguageValid || isGenerating}
+                  className="px-3 py-1.5 text-xs font-medium rounded-md bg-indigo-500 text-white hover:bg-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  data-testid="confirm-generate-btn"
+                >
+                  Generate
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>,
+        document.body,
+      )
+    : null;
 
   const { languageCoverages, detectedLanguages, translatableStrings, stringTranslations } = translationData;
 
@@ -156,10 +219,11 @@ const TranslationDashboard: React.FC<TranslationDashboardProps> = ({ translation
   const fileRows = useMemo(() => {
     if (!activeCoverage) return [];
     let rows = activeCoverage.fileBreakdown;
+    const getEffectiveTranslated = (row: TranslationFileBreakdown) => row.translatedCount - row.staleCount;
 
     // Status filter
-    if (statusFilter === 'translated') rows = rows.filter(r => r.completionPercent === 100);
-    else if (statusFilter === 'untranslated') rows = rows.filter(r => r.translatedCount < r.totalStrings);
+    if (statusFilter === 'translated') rows = rows.filter(r => getEffectiveTranslated(r) > 0);
+    else if (statusFilter === 'untranslated') rows = rows.filter(r => getEffectiveTranslated(r) < r.totalStrings);
     else if (statusFilter === 'stale') rows = rows.filter(r => r.staleCount > 0);
 
     // Text filter
@@ -209,18 +273,20 @@ const TranslationDashboard: React.FC<TranslationDashboardProps> = ({ translation
   // --- Empty state ---
   if (detectedLanguages.length === 0 && translatableStrings.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-full text-secondary gap-4 px-8">
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-16 w-16 opacity-40" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" />
-        </svg>
-        <h3 className="text-lg font-semibold text-primary">No Translations Detected</h3>
-        <p className="text-sm text-center max-w-md">
-          Ren'Py stores translations under <code className="px-1 py-0.5 bg-secondary rounded text-xs">game/tl/&lt;language&gt;/</code> directories.
-          Generate translations with Ren'Py's built-in tool or create translation files manually to see coverage here.
-        </p>
-        {!showGenerateForm && generateButton}
-        {generateForm}
-      </div>
+      <>
+        <div className="flex flex-col items-center justify-center h-full text-secondary gap-4 px-8">
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-16 w-16 opacity-40" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" />
+          </svg>
+          <h3 className="text-lg font-semibold text-primary">No Translations Detected</h3>
+          <p className="text-sm text-center max-w-md">
+            Ren'Py stores translations under <code className="px-1 py-0.5 bg-secondary rounded text-xs">game/tl/&lt;language&gt;/</code> directories.
+            Generate translations with Ren'Py's built-in tool or create translation files manually to see coverage here.
+          </p>
+          {!showGenerateForm && generateButton}
+        </div>
+        {generateModal}
+      </>
     );
   }
 
@@ -232,7 +298,6 @@ const TranslationDashboard: React.FC<TranslationDashboardProps> = ({ translation
           <SectionLabel>Language Coverage</SectionLabel>
           {!showGenerateForm && generateButton}
         </div>
-        {generateForm}
         <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
           {languageCoverages.map(cov => (
             <button
@@ -335,21 +400,26 @@ const TranslationDashboard: React.FC<TranslationDashboardProps> = ({ translation
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-primary">
-                  {fileRows.map(row => (
-                    <tr key={row.sourceFilePath} className="hover:bg-tertiary-hover">
-                      <td className="px-3 py-2 font-mono text-xs text-primary">{row.sourceFilePath}</td>
-                      <td className="px-3 py-2 text-center">{row.totalStrings}</td>
-                      <td className="px-3 py-2 text-center text-green-600 dark:text-green-400">{row.translatedCount}</td>
-                      <td className="px-3 py-2 text-center text-red-600 dark:text-red-400">{row.totalStrings - row.translatedCount}</td>
-                      <td className="px-3 py-2 text-center text-amber-600 dark:text-amber-400">{row.staleCount}</td>
-                      <td className="px-3 py-2">
-                        <div className="flex items-center gap-2">
-                          <ProgressBar percent={row.completionPercent} />
-                          <span className="text-xs text-secondary w-8 text-right">{row.completionPercent}%</span>
-                        </div>
-                      </td>
-                    </tr>
-                  ))}
+                  {fileRows.map(row => {
+                    const effectiveTranslated = row.translatedCount - row.staleCount;
+                    const effectiveUntranslated = row.totalStrings - effectiveTranslated;
+
+                    return (
+                      <tr key={row.sourceFilePath} className="hover:bg-tertiary-hover">
+                        <td className="px-3 py-2 font-mono text-xs text-primary">{row.sourceFilePath}</td>
+                        <td className="px-3 py-2 text-center">{row.totalStrings}</td>
+                        <td className="px-3 py-2 text-center text-green-600 dark:text-green-400">{effectiveTranslated}</td>
+                        <td className="px-3 py-2 text-center text-red-600 dark:text-red-400">{effectiveUntranslated}</td>
+                        <td className="px-3 py-2 text-center text-amber-600 dark:text-amber-400">{row.staleCount}</td>
+                        <td className="px-3 py-2">
+                          <div className="flex items-center gap-2">
+                            <ProgressBar percent={row.completionPercent} />
+                            <span className="text-xs text-secondary w-8 text-right">{row.completionPercent}%</span>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
                   {fileRows.length === 0 && (
                     <tr><td colSpan={6} className="px-3 py-6 text-center text-secondary text-xs">No matching files</td></tr>
                   )}
@@ -424,6 +494,7 @@ const TranslationDashboard: React.FC<TranslationDashboardProps> = ({ translation
           </div>
         </section>
       </div>
+      {generateModal}
     </div>
   );
 };

--- a/components/TranslationDashboard.tsx
+++ b/components/TranslationDashboard.tsx
@@ -225,9 +225,9 @@ const TranslationDashboard: React.FC<TranslationDashboardProps> = ({ translation
   }
 
   return (
-    <div className="h-full overflow-y-auto p-6 space-y-6">
-      {/* ── Section 1: Language Overview Cards ── */}
-      <section>
+    <div className="h-full flex flex-col overflow-hidden">
+      {/* ── Section 1: Language Overview Cards (sticky) ── */}
+      <section className="flex-none px-6 pt-6 pb-4 border-b border-primary">
         <div className="flex items-center justify-between mb-3">
           <SectionLabel>Language Coverage</SectionLabel>
           {!showGenerateForm && generateButton}
@@ -254,13 +254,10 @@ const TranslationDashboard: React.FC<TranslationDashboardProps> = ({ translation
         </div>
       </section>
 
-      {/* ── Section 2: File Breakdown Table ── */}
+      {/* ── Filters (shared between both tables) ── */}
       {activeCoverage && (
-        <section>
-          <SectionLabel>File Breakdown — {activeLang}</SectionLabel>
-
-          {/* Filters */}
-          <div className="flex flex-wrap items-center gap-2 mb-3">
+        <div className="flex-none px-6 pt-4 pb-2">
+          <div className="flex flex-wrap items-center gap-2">
             {/* Language pills */}
             <div className="flex rounded-md border border-primary overflow-hidden text-xs flex-none">
               {detectedLanguages.map(lang => (
@@ -306,119 +303,127 @@ const TranslationDashboard: React.FC<TranslationDashboardProps> = ({ translation
             </div>
             <span className="text-xs text-secondary flex-none">{fileRows.length} file{fileRows.length !== 1 ? 's' : ''}</span>
           </div>
-
-          {/* Table */}
-          <div className="overflow-x-auto rounded-lg border border-primary">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="bg-tertiary text-left text-xs font-semibold text-secondary uppercase tracking-wider">
-                  {([
-                    ['file', 'File'],
-                    ['total', 'Total'],
-                    ['translated', 'Translated'],
-                    ['untranslated', 'Untranslated'],
-                    ['stale', 'Stale'],
-                    ['completion', 'Completion'],
-                  ] as [FileSortKey, string][]).map(([key, label]) => (
-                    <th
-                      key={key}
-                      className="px-3 py-2 cursor-pointer select-none hover:text-primary"
-                      onClick={() => toggleSort(key)}
-                    >
-                      {label}<SortIcon col={key} />
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-primary">
-                {fileRows.map(row => (
-                  <tr key={row.sourceFilePath} className="hover:bg-tertiary-hover">
-                    <td className="px-3 py-2 font-mono text-xs text-primary">{row.sourceFilePath}</td>
-                    <td className="px-3 py-2 text-center">{row.totalStrings}</td>
-                    <td className="px-3 py-2 text-center text-green-600 dark:text-green-400">{row.translatedCount}</td>
-                    <td className="px-3 py-2 text-center text-red-600 dark:text-red-400">{row.totalStrings - row.translatedCount}</td>
-                    <td className="px-3 py-2 text-center text-amber-600 dark:text-amber-400">{row.staleCount}</td>
-                    <td className="px-3 py-2">
-                      <div className="flex items-center gap-2">
-                        <ProgressBar percent={row.completionPercent} />
-                        <span className="text-xs text-secondary w-8 text-right">{row.completionPercent}%</span>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-                {fileRows.length === 0 && (
-                  <tr><td colSpan={6} className="px-3 py-6 text-center text-secondary text-xs">No matching files</td></tr>
-                )}
-              </tbody>
-            </table>
-          </div>
-        </section>
+        </div>
       )}
 
-      {/* ── Section 3: String-Level View (Virtual) ── */}
-      <section>
-        <SectionLabel>Translatable Strings ({stringItems.length})</SectionLabel>
-        <div
-          ref={containerRef}
-          onScroll={handleScroll}
-          className="h-[400px] overflow-y-auto border border-primary rounded-lg"
-        >
-          <div style={{ height: totalHeight, position: 'relative' }}>
-            {virtualItems.map(({ item: s, index, offsetTop }) => {
-              const translations = stringTranslations.get(s.id);
+      {/* ── Bottom half: two tables split 50/50 ── */}
+      <div className="flex-1 min-h-0 flex flex-col px-6 pb-6 gap-4">
+        {/* ── Section 2: File Breakdown Table ── */}
+        {activeCoverage && (
+          <section className="flex-1 min-h-0 flex flex-col">
+            <SectionLabel>File Breakdown — {activeLang}</SectionLabel>
+            <div className="flex-1 min-h-0 overflow-auto rounded-lg border border-primary">
+              <table className="w-full text-sm">
+                <thead className="sticky top-0 z-10">
+                  <tr className="bg-tertiary text-left text-xs font-semibold text-secondary uppercase tracking-wider">
+                    {([
+                      ['file', 'File'],
+                      ['total', 'Total'],
+                      ['translated', 'Translated'],
+                      ['untranslated', 'Untranslated'],
+                      ['stale', 'Stale'],
+                      ['completion', 'Completion'],
+                    ] as [FileSortKey, string][]).map(([key, label]) => (
+                      <th
+                        key={key}
+                        className="px-3 py-2 cursor-pointer select-none hover:text-primary"
+                        onClick={() => toggleSort(key)}
+                      >
+                        {label}<SortIcon col={key} />
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-primary">
+                  {fileRows.map(row => (
+                    <tr key={row.sourceFilePath} className="hover:bg-tertiary-hover">
+                      <td className="px-3 py-2 font-mono text-xs text-primary">{row.sourceFilePath}</td>
+                      <td className="px-3 py-2 text-center">{row.totalStrings}</td>
+                      <td className="px-3 py-2 text-center text-green-600 dark:text-green-400">{row.translatedCount}</td>
+                      <td className="px-3 py-2 text-center text-red-600 dark:text-red-400">{row.totalStrings - row.translatedCount}</td>
+                      <td className="px-3 py-2 text-center text-amber-600 dark:text-amber-400">{row.staleCount}</td>
+                      <td className="px-3 py-2">
+                        <div className="flex items-center gap-2">
+                          <ProgressBar percent={row.completionPercent} />
+                          <span className="text-xs text-secondary w-8 text-right">{row.completionPercent}%</span>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                  {fileRows.length === 0 && (
+                    <tr><td colSpan={6} className="px-3 py-6 text-center text-secondary text-xs">No matching files</td></tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
 
-              return (
-                <div
-                  key={s.id}
-                  className="absolute left-0 right-0 flex items-center gap-3 px-3 border-b border-primary hover:bg-tertiary-hover cursor-pointer"
-                  style={{ top: offsetTop, height: 56 }}
-                  onClick={() => onOpenBlock(s.blockId, s.line)}
-                  role="button"
-                  tabIndex={0}
-                  onKeyDown={e => { if (e.key === 'Enter') onOpenBlock(s.blockId, s.line); }}
-                  data-testid={`string-row-${index}`}
-                >
-                  {/* Type badge */}
-                  <span className={`text-[10px] font-semibold uppercase px-1.5 py-0.5 rounded flex-none ${
-                    s.type === 'dialogue' ? 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300' :
-                    s.type === 'narration' ? 'bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300' :
-                    'bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300'
-                  }`}>
-                    {s.type === 'menu-choice' ? 'choice' : s.type}
-                  </span>
+        {/* ── Section 3: String-Level View (Virtual) ── */}
+        <section className="flex-1 min-h-0 flex flex-col">
+          <SectionLabel>Translatable Strings ({stringItems.length})</SectionLabel>
+          <div
+            ref={containerRef}
+            onScroll={handleScroll}
+            className="flex-1 min-h-0 overflow-y-auto border border-primary rounded-lg"
+          >
+            <div style={{ height: totalHeight, position: 'relative' }}>
+              {virtualItems.map(({ item: s, index, offsetTop }) => {
+                const translations = stringTranslations.get(s.id);
 
-                  {/* Source text */}
-                  <div className="flex-1 min-w-0">
-                    <div className="text-sm text-primary truncate">
-                      {s.characterTag && <span className="font-semibold text-indigo-500 mr-1">{s.characterTag}:</span>}
-                      {s.sourceText}
+                return (
+                  <div
+                    key={s.id}
+                    className="absolute left-0 right-0 flex items-center gap-3 px-3 border-b border-primary hover:bg-tertiary-hover cursor-pointer"
+                    style={{ top: offsetTop, height: 56 }}
+                    onClick={() => onOpenBlock(s.blockId, s.line)}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={e => { if (e.key === 'Enter') onOpenBlock(s.blockId, s.line); }}
+                    data-testid={`string-row-${index}`}
+                  >
+                    {/* Type badge */}
+                    <span className={`text-[10px] font-semibold uppercase px-1.5 py-0.5 rounded flex-none ${
+                      s.type === 'dialogue' ? 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300' :
+                      s.type === 'narration' ? 'bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300' :
+                      'bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300'
+                    }`}>
+                      {s.type === 'menu-choice' ? 'choice' : s.type}
+                    </span>
+
+                    {/* Source text */}
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm text-primary truncate">
+                        {s.characterTag && <span className="font-semibold text-indigo-500 mr-1">{s.characterTag}:</span>}
+                        {s.sourceText}
+                      </div>
+                      <div className="text-[10px] text-secondary truncate">{s.filePath}:{s.line}</div>
                     </div>
-                    <div className="text-[10px] text-secondary truncate">{s.filePath}:{s.line}</div>
-                  </div>
 
-                  {/* Language status badges */}
-                  <div className="flex gap-1 flex-none">
-                    {detectedLanguages.map(lang => {
-                      const t = translations?.get(lang);
-                      const isStale = t && t.translatedText === s.sourceText;
-                      const color = t
-                        ? isStale
-                          ? 'bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300'
-                          : 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300'
-                        : 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300';
-                      return (
-                        <span key={lang} className={`text-[9px] font-bold uppercase px-1 py-0.5 rounded ${color}`} title={t ? (isStale ? `${lang}: stale` : `${lang}: ${t.translatedText}`) : `${lang}: missing`}>
-                          {lang.slice(0, 2)}
-                        </span>
-                      );
-                    })}
+                    {/* Language status badges */}
+                    <div className="flex gap-1 flex-none">
+                      {detectedLanguages.map(lang => {
+                        const t = translations?.get(lang);
+                        const isStale = t && t.translatedText === s.sourceText;
+                        const color = t
+                          ? isStale
+                            ? 'bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300'
+                            : 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300'
+                          : 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300';
+                        return (
+                          <span key={lang} className={`text-[9px] font-bold uppercase px-1 py-0.5 rounded ${color}`} title={t ? (isStale ? `${lang}: stale` : `${lang}: ${t.translatedText}`) : `${lang}: missing`}>
+                            {lang.slice(0, 2)}
+                          </span>
+                        );
+                      })}
+                    </div>
                   </div>
-                </div>
-              );
-            })}
+                );
+              })}
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
+      </div>
     </div>
   );
 };

--- a/components/TranslationDashboard.tsx
+++ b/components/TranslationDashboard.tsx
@@ -246,7 +246,7 @@ const TranslationDashboard: React.FC<TranslationDashboardProps> = ({ translation
               <span className="text-2xl font-bold text-primary">{cov.completionPercent}%</span>
               <ProgressBar percent={cov.completionPercent} />
               <div className="flex justify-between text-xs text-secondary">
-                <span>{cov.translatedCount}/{cov.totalStrings}</span>
+                <span>{cov.translatedCount - cov.staleCount}/{cov.totalStrings}</span>
                 {cov.staleCount > 0 && <span className="text-amber-500">{cov.staleCount} stale</span>}
               </div>
             </button>

--- a/components/TranslationDashboard.tsx
+++ b/components/TranslationDashboard.tsx
@@ -16,6 +16,9 @@ interface TranslationDashboardProps {
   translationData: TranslationAnalysisResult;
   blocks: Block[];
   onOpenBlock: (blockId: string, line?: number) => void;
+  onGenerateTranslations: (language: string) => Promise<void>;
+  isGenerating: boolean;
+  isRenpyPathValid: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -68,13 +71,76 @@ type StatusFilter = 'all' | 'translated' | 'untranslated' | 'stale';
 // Main component
 // ---------------------------------------------------------------------------
 
-const TranslationDashboard: React.FC<TranslationDashboardProps> = ({ translationData, blocks: _blocks, onOpenBlock }) => {
+const LANGUAGE_PATTERN = /^[a-z][a-z0-9_]*$/;
+
+const TranslationDashboard: React.FC<TranslationDashboardProps> = ({ translationData, blocks: _blocks, onOpenBlock, onGenerateTranslations, isGenerating, isRenpyPathValid }) => {
   // --- State ---
   const [selectedLanguage, setSelectedLanguage] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
   const [textFilter, setTextFilter] = useState('');
   const [fileSortKey, setFileSortKey] = useState<FileSortKey>('file');
   const [fileSortDir, setFileSortDir] = useState<SortDir>('asc');
+  const [showGenerateForm, setShowGenerateForm] = useState(false);
+  const [languageInput, setLanguageInput] = useState('');
+
+  const isLanguageValid = LANGUAGE_PATTERN.test(languageInput);
+
+  const handleGenerate = useCallback(async () => {
+    if (!isLanguageValid) return;
+    await onGenerateTranslations(languageInput);
+    setLanguageInput('');
+    setShowGenerateForm(false);
+  }, [languageInput, isLanguageValid, onGenerateTranslations]);
+
+  const generateButton = (
+    <button
+      onClick={() => setShowGenerateForm(true)}
+      disabled={!isRenpyPathValid || isGenerating}
+      title={!isRenpyPathValid ? 'Configure Ren\'Py SDK path in settings first' : undefined}
+      className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-indigo-500 text-white hover:bg-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      data-testid="generate-translations-btn"
+    >
+      {isGenerating ? (
+        <>
+          <svg className="animate-spin h-3.5 w-3.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" /><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" /></svg>
+          Generating...
+        </>
+      ) : 'Generate Translations'}
+    </button>
+  );
+
+  const generateForm = showGenerateForm ? (
+    <div className="flex items-center gap-2 mt-2" data-testid="generate-form">
+      <input
+        type="text"
+        placeholder='e.g. "french", "japanese"'
+        value={languageInput}
+        onChange={e => setLanguageInput(e.target.value.toLowerCase())}
+        onKeyDown={e => { if (e.key === 'Enter') handleGenerate(); if (e.key === 'Escape') setShowGenerateForm(false); }}
+        className="px-2 py-1 text-xs bg-secondary border border-primary rounded focus:outline-none focus:ring-1 focus:ring-indigo-400 text-primary placeholder:text-secondary w-48"
+        data-testid="language-input"
+        autoFocus
+      />
+      <button
+        onClick={handleGenerate}
+        disabled={!isLanguageValid || isGenerating}
+        className="px-3 py-1 text-xs font-medium rounded-md bg-indigo-500 text-white hover:bg-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        data-testid="confirm-generate-btn"
+      >
+        Generate
+      </button>
+      <button
+        onClick={() => { setShowGenerateForm(false); setLanguageInput(''); }}
+        className="px-3 py-1 text-xs font-medium rounded-md bg-secondary text-secondary hover:bg-tertiary border border-primary transition-colors"
+        data-testid="cancel-generate-btn"
+      >
+        Cancel
+      </button>
+      {languageInput && !isLanguageValid && (
+        <span className="text-xs text-red-500" data-testid="language-validation-error">Lowercase letters, numbers, underscores only. Must start with a letter.</span>
+      )}
+    </div>
+  ) : null;
 
   const { languageCoverages, detectedLanguages, translatableStrings, stringTranslations } = translationData;
 
@@ -122,7 +188,7 @@ const TranslationDashboard: React.FC<TranslationDashboardProps> = ({ translation
     });
   }, [translatableStrings, activeLang, textFilter, statusFilter, stringTranslations]);
 
-  const { containerRef, onScroll, virtualItems, totalHeight } = useVirtualList(stringItems, 56);
+  const { containerRef, handleScroll, virtualItems, totalHeight } = useVirtualList(stringItems, 56);
 
   const toggleSort = useCallback((key: FileSortKey) => {
     setFileSortKey(prev => {
@@ -152,6 +218,8 @@ const TranslationDashboard: React.FC<TranslationDashboardProps> = ({ translation
           Ren'Py stores translations under <code className="px-1 py-0.5 bg-secondary rounded text-xs">game/tl/&lt;language&gt;/</code> directories.
           Generate translations with Ren'Py's built-in tool or create translation files manually to see coverage here.
         </p>
+        {!showGenerateForm && generateButton}
+        {generateForm}
       </div>
     );
   }
@@ -160,7 +228,11 @@ const TranslationDashboard: React.FC<TranslationDashboardProps> = ({ translation
     <div className="h-full overflow-y-auto p-6 space-y-6">
       {/* ── Section 1: Language Overview Cards ── */}
       <section>
-        <SectionLabel>Language Coverage</SectionLabel>
+        <div className="flex items-center justify-between mb-3">
+          <SectionLabel>Language Coverage</SectionLabel>
+          {!showGenerateForm && generateButton}
+        </div>
+        {generateForm}
         <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
           {languageCoverages.map(cov => (
             <button
@@ -288,7 +360,7 @@ const TranslationDashboard: React.FC<TranslationDashboardProps> = ({ translation
         <SectionLabel>Translatable Strings ({stringItems.length})</SectionLabel>
         <div
           ref={containerRef}
-          onScroll={onScroll}
+          onScroll={handleScroll}
           className="h-[400px] overflow-y-auto border border-primary rounded-lg"
         >
           <div style={{ height: totalHeight, position: 'relative' }}>

--- a/components/TranslationDashboard.tsx
+++ b/components/TranslationDashboard.tsx
@@ -1,0 +1,354 @@
+/**
+ * @file TranslationDashboard.tsx
+ * @description Read-only dashboard that displays translation coverage across
+ * detected languages. Three sections: language overview cards, file breakdown
+ * table, and a virtual string-level view.
+ */
+import React, { useState, useMemo, useCallback } from 'react';
+import type { TranslationAnalysisResult, LanguageCoverage, TranslationFileBreakdown, Block } from '../types';
+import { useVirtualList } from '../hooks/useVirtualList';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface TranslationDashboardProps {
+  translationData: TranslationAnalysisResult;
+  blocks: Block[];
+  onOpenBlock: (blockId: string, line?: number) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+const SectionLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <h2 className="text-xs font-semibold text-secondary uppercase tracking-widest mb-3">{children}</h2>
+);
+
+const ProgressBar: React.FC<{ percent: number }> = ({ percent }) => {
+  const color = percent > 80 ? 'bg-green-500' : percent >= 40 ? 'bg-yellow-500' : 'bg-red-500';
+  return (
+    <div className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+      <div className={`h-full rounded-full transition-all ${color}`} style={{ width: `${Math.min(percent, 100)}%` }} />
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Sort helpers
+// ---------------------------------------------------------------------------
+
+type FileSortKey = 'file' | 'total' | 'translated' | 'untranslated' | 'stale' | 'completion';
+type SortDir = 'asc' | 'desc';
+
+function sortFileBreakdown(rows: TranslationFileBreakdown[], key: FileSortKey, dir: SortDir): TranslationFileBreakdown[] {
+  const sorted = [...rows];
+  const mult = dir === 'asc' ? 1 : -1;
+  sorted.sort((a, b) => {
+    switch (key) {
+      case 'file': return mult * a.sourceFilePath.localeCompare(b.sourceFilePath);
+      case 'total': return mult * (a.totalStrings - b.totalStrings);
+      case 'translated': return mult * (a.translatedCount - b.translatedCount);
+      case 'untranslated': return mult * ((a.totalStrings - a.translatedCount) - (b.totalStrings - b.translatedCount));
+      case 'stale': return mult * (a.staleCount - b.staleCount);
+      case 'completion': return mult * (a.completionPercent - b.completionPercent);
+    }
+  });
+  return sorted;
+}
+
+// ---------------------------------------------------------------------------
+// Status filter type
+// ---------------------------------------------------------------------------
+
+type StatusFilter = 'all' | 'translated' | 'untranslated' | 'stale';
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+const TranslationDashboard: React.FC<TranslationDashboardProps> = ({ translationData, blocks: _blocks, onOpenBlock }) => {
+  // --- State ---
+  const [selectedLanguage, setSelectedLanguage] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [textFilter, setTextFilter] = useState('');
+  const [fileSortKey, setFileSortKey] = useState<FileSortKey>('file');
+  const [fileSortDir, setFileSortDir] = useState<SortDir>('asc');
+
+  const { languageCoverages, detectedLanguages, translatableStrings, stringTranslations } = translationData;
+
+  // Auto-select first language if none selected
+  const activeLang = selectedLanguage && detectedLanguages.includes(selectedLanguage) ? selectedLanguage : detectedLanguages[0] ?? null;
+
+  const activeCoverage: LanguageCoverage | null = useMemo(
+    () => languageCoverages.find(c => c.language === activeLang) ?? null,
+    [languageCoverages, activeLang],
+  );
+
+  // --- File breakdown (filtered + sorted) ---
+  const fileRows = useMemo(() => {
+    if (!activeCoverage) return [];
+    let rows = activeCoverage.fileBreakdown;
+
+    // Status filter
+    if (statusFilter === 'translated') rows = rows.filter(r => r.completionPercent === 100);
+    else if (statusFilter === 'untranslated') rows = rows.filter(r => r.translatedCount < r.totalStrings);
+    else if (statusFilter === 'stale') rows = rows.filter(r => r.staleCount > 0);
+
+    // Text filter
+    if (textFilter) {
+      const q = textFilter.toLowerCase();
+      rows = rows.filter(r => r.sourceFilePath.toLowerCase().includes(q));
+    }
+
+    return sortFileBreakdown(rows, fileSortKey, fileSortDir);
+  }, [activeCoverage, statusFilter, textFilter, fileSortKey, fileSortDir]);
+
+  // --- String-level items ---
+  const stringItems = useMemo(() => {
+    if (!activeLang) return translatableStrings;
+    const q = textFilter.toLowerCase();
+    return translatableStrings.filter(s => {
+      if (q && !s.sourceText.toLowerCase().includes(q) && !s.filePath.toLowerCase().includes(q)) return false;
+      if (statusFilter === 'all') return true;
+      const translations = stringTranslations.get(s.id);
+      const hasTranslation = translations?.has(activeLang);
+      const isStale = hasTranslation && translations!.get(activeLang)!.translatedText === s.sourceText;
+      if (statusFilter === 'translated') return hasTranslation && !isStale;
+      if (statusFilter === 'untranslated') return !hasTranslation;
+      if (statusFilter === 'stale') return isStale;
+      return true;
+    });
+  }, [translatableStrings, activeLang, textFilter, statusFilter, stringTranslations]);
+
+  const { containerRef, onScroll, virtualItems, totalHeight } = useVirtualList(stringItems, 56);
+
+  const toggleSort = useCallback((key: FileSortKey) => {
+    setFileSortKey(prev => {
+      if (prev === key) {
+        setFileSortDir(d => d === 'asc' ? 'desc' : 'asc');
+        return prev;
+      }
+      setFileSortDir('asc');
+      return key;
+    });
+  }, []);
+
+  const SortIcon: React.FC<{ col: FileSortKey }> = ({ col }) => {
+    if (fileSortKey !== col) return null;
+    return <span className="ml-0.5">{fileSortDir === 'asc' ? '\u25B2' : '\u25BC'}</span>;
+  };
+
+  // --- Empty state ---
+  if (detectedLanguages.length === 0 && translatableStrings.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full text-secondary gap-4 px-8">
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-16 w-16 opacity-40" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9" />
+        </svg>
+        <h3 className="text-lg font-semibold text-primary">No Translations Detected</h3>
+        <p className="text-sm text-center max-w-md">
+          Ren'Py stores translations under <code className="px-1 py-0.5 bg-secondary rounded text-xs">game/tl/&lt;language&gt;/</code> directories.
+          Generate translations with Ren'Py's built-in tool or create translation files manually to see coverage here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-y-auto p-6 space-y-6">
+      {/* ── Section 1: Language Overview Cards ── */}
+      <section>
+        <SectionLabel>Language Coverage</SectionLabel>
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+          {languageCoverages.map(cov => (
+            <button
+              key={cov.language}
+              onClick={() => setSelectedLanguage(cov.language)}
+              className={`bg-secondary rounded-lg p-4 flex flex-col gap-2 text-left transition-shadow ${
+                activeLang === cov.language ? 'ring-2 ring-indigo-500' : 'hover:ring-1 hover:ring-indigo-400'
+              }`}
+            >
+              <span className="text-xs font-semibold text-secondary uppercase tracking-wide">{cov.language}</span>
+              <span className="text-2xl font-bold text-primary">{cov.completionPercent}%</span>
+              <ProgressBar percent={cov.completionPercent} />
+              <div className="flex justify-between text-xs text-secondary">
+                <span>{cov.translatedCount}/{cov.totalStrings}</span>
+                {cov.staleCount > 0 && <span className="text-amber-500">{cov.staleCount} stale</span>}
+              </div>
+            </button>
+          ))}
+        </div>
+      </section>
+
+      {/* ── Section 2: File Breakdown Table ── */}
+      {activeCoverage && (
+        <section>
+          <SectionLabel>File Breakdown — {activeLang}</SectionLabel>
+
+          {/* Filters */}
+          <div className="flex flex-wrap items-center gap-2 mb-3">
+            {/* Language pills */}
+            <div className="flex rounded-md border border-primary overflow-hidden text-xs flex-none">
+              {detectedLanguages.map(lang => (
+                <button
+                  key={lang}
+                  onClick={() => setSelectedLanguage(lang)}
+                  className={`px-2.5 py-1 capitalize border-r border-primary last:border-0 transition-colors ${
+                    activeLang === lang ? 'bg-indigo-500 text-white' : 'bg-secondary text-secondary hover:bg-tertiary'
+                  }`}
+                >
+                  {lang}
+                </button>
+              ))}
+            </div>
+
+            {/* Status pills */}
+            <div className="flex rounded-md border border-primary overflow-hidden text-xs flex-none">
+              {(['all', 'translated', 'untranslated', 'stale'] as StatusFilter[]).map(s => (
+                <button
+                  key={s}
+                  onClick={() => setStatusFilter(s)}
+                  className={`px-2.5 py-1 capitalize border-r border-primary last:border-0 transition-colors ${
+                    statusFilter === s ? 'bg-indigo-500 text-white' : 'bg-secondary text-secondary hover:bg-tertiary'
+                  }`}
+                >
+                  {s === 'all' ? 'All Status' : s}
+                </button>
+              ))}
+            </div>
+
+            {/* Text search */}
+            <div className="relative flex-1 min-w-[140px]">
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5 absolute left-2 top-1/2 -translate-y-1/2 text-secondary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+              <input
+                type="text"
+                placeholder="Filter files or strings..."
+                value={textFilter}
+                onChange={e => setTextFilter(e.target.value)}
+                className="w-full pl-7 pr-2 py-1 text-xs bg-secondary border border-primary rounded focus:outline-none focus:ring-1 focus:ring-indigo-400 text-primary placeholder:text-secondary"
+              />
+            </div>
+            <span className="text-xs text-secondary flex-none">{fileRows.length} file{fileRows.length !== 1 ? 's' : ''}</span>
+          </div>
+
+          {/* Table */}
+          <div className="overflow-x-auto rounded-lg border border-primary">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-tertiary text-left text-xs font-semibold text-secondary uppercase tracking-wider">
+                  {([
+                    ['file', 'File'],
+                    ['total', 'Total'],
+                    ['translated', 'Translated'],
+                    ['untranslated', 'Untranslated'],
+                    ['stale', 'Stale'],
+                    ['completion', 'Completion'],
+                  ] as [FileSortKey, string][]).map(([key, label]) => (
+                    <th
+                      key={key}
+                      className="px-3 py-2 cursor-pointer select-none hover:text-primary"
+                      onClick={() => toggleSort(key)}
+                    >
+                      {label}<SortIcon col={key} />
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-primary">
+                {fileRows.map(row => (
+                  <tr key={row.sourceFilePath} className="hover:bg-tertiary-hover">
+                    <td className="px-3 py-2 font-mono text-xs text-primary">{row.sourceFilePath}</td>
+                    <td className="px-3 py-2 text-center">{row.totalStrings}</td>
+                    <td className="px-3 py-2 text-center text-green-600 dark:text-green-400">{row.translatedCount}</td>
+                    <td className="px-3 py-2 text-center text-red-600 dark:text-red-400">{row.totalStrings - row.translatedCount}</td>
+                    <td className="px-3 py-2 text-center text-amber-600 dark:text-amber-400">{row.staleCount}</td>
+                    <td className="px-3 py-2">
+                      <div className="flex items-center gap-2">
+                        <ProgressBar percent={row.completionPercent} />
+                        <span className="text-xs text-secondary w-8 text-right">{row.completionPercent}%</span>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+                {fileRows.length === 0 && (
+                  <tr><td colSpan={6} className="px-3 py-6 text-center text-secondary text-xs">No matching files</td></tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      {/* ── Section 3: String-Level View (Virtual) ── */}
+      <section>
+        <SectionLabel>Translatable Strings ({stringItems.length})</SectionLabel>
+        <div
+          ref={containerRef}
+          onScroll={onScroll}
+          className="h-[400px] overflow-y-auto border border-primary rounded-lg"
+        >
+          <div style={{ height: totalHeight, position: 'relative' }}>
+            {virtualItems.map(({ item: s, index, offsetTop }) => {
+              const translations = stringTranslations.get(s.id);
+
+              return (
+                <div
+                  key={s.id}
+                  className="absolute left-0 right-0 flex items-center gap-3 px-3 border-b border-primary hover:bg-tertiary-hover cursor-pointer"
+                  style={{ top: offsetTop, height: 56 }}
+                  onClick={() => onOpenBlock(s.blockId, s.line)}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={e => { if (e.key === 'Enter') onOpenBlock(s.blockId, s.line); }}
+                  data-testid={`string-row-${index}`}
+                >
+                  {/* Type badge */}
+                  <span className={`text-[10px] font-semibold uppercase px-1.5 py-0.5 rounded flex-none ${
+                    s.type === 'dialogue' ? 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300' :
+                    s.type === 'narration' ? 'bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300' :
+                    'bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300'
+                  }`}>
+                    {s.type === 'menu-choice' ? 'choice' : s.type}
+                  </span>
+
+                  {/* Source text */}
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm text-primary truncate">
+                      {s.characterTag && <span className="font-semibold text-indigo-500 mr-1">{s.characterTag}:</span>}
+                      {s.sourceText}
+                    </div>
+                    <div className="text-[10px] text-secondary truncate">{s.filePath}:{s.line}</div>
+                  </div>
+
+                  {/* Language status badges */}
+                  <div className="flex gap-1 flex-none">
+                    {detectedLanguages.map(lang => {
+                      const t = translations?.get(lang);
+                      const isStale = t && t.translatedText === s.sourceText;
+                      const color = t
+                        ? isStale
+                          ? 'bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300'
+                          : 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300'
+                        : 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300';
+                      return (
+                        <span key={lang} className={`text-[9px] font-bold uppercase px-1 py-0.5 rounded ${color}`} title={t ? (isStale ? `${lang}: stale` : `${lang}: ${t.translatedText}`) : `${lang}: missing`}>
+                          {lang.slice(0, 2)}
+                        </span>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default TranslationDashboard;

--- a/electron.js
+++ b/electron.js
@@ -852,6 +852,39 @@ app.whenReady().then(() => {
     }
   });
 
+  ipcMain.handle('renpy:generate-translations', async (event, sdkDir, projectPath, language) => {
+    const executable = getRenpyExecutable(sdkDir);
+    if (!executable) throw new Error('Ren\'Py SDK path is not configured');
+
+    return new Promise((resolve, reject) => {
+      let stdout = '';
+      let stderr = '';
+      const proc = spawn(executable, [projectPath, 'translate', language]);
+
+      const timeout = setTimeout(() => {
+        proc.kill();
+        reject(new Error('Translation generation timed out after 60 seconds'));
+      }, 60000);
+
+      proc.stdout.on('data', (data) => { stdout += data.toString(); });
+      proc.stderr.on('data', (data) => { stderr += data.toString(); });
+
+      proc.on('close', (code) => {
+        clearTimeout(timeout);
+        if (code === 0) {
+          resolve({ success: true, output: stdout });
+        } else {
+          reject(new Error(stderr || `Process exited with code ${code}`));
+        }
+      });
+
+      proc.on('error', (err) => {
+        clearTimeout(timeout);
+        reject(new Error(`Failed to start Ren'Py: ${err.message}`));
+      });
+    });
+  });
+
   ipcMain.handle('dialog:createProject', async () => {
     const { canceled, filePath } = await dialog.showSaveDialog({
         title: 'Create New Ren\'Py Project',

--- a/electron.js
+++ b/electron.js
@@ -859,9 +859,12 @@ app.whenReady().then(() => {
     return new Promise((resolve, reject) => {
       let stdout = '';
       let stderr = '';
+      let settled = false;
       const proc = spawn(executable, [projectPath, 'translate', language]);
 
       const timeout = setTimeout(() => {
+        if (settled) return;
+        settled = true;
         proc.kill();
         reject(new Error('Translation generation timed out after 60 seconds'));
       }, 60000);
@@ -871,6 +874,8 @@ app.whenReady().then(() => {
 
       proc.on('close', (code) => {
         clearTimeout(timeout);
+        if (settled) return;
+        settled = true;
         if (code === 0) {
           resolve({ success: true, output: stdout });
         } else {
@@ -880,6 +885,8 @@ app.whenReady().then(() => {
 
       proc.on('error', (err) => {
         clearTimeout(timeout);
+        if (settled) return;
+        settled = true;
         reject(new Error(`Failed to start Ren'Py: ${err.message}`));
       });
     });

--- a/electron.js
+++ b/electron.js
@@ -879,7 +879,8 @@ app.whenReady().then(() => {
         if (code === 0) {
           resolve({ success: true, output: stdout });
         } else {
-          resolve({ success: false, output: stdout, error: stderr || `Process exited with code ${code}` });
+          const combined = [stderr, stdout].filter(Boolean).join('\n').trim();
+          resolve({ success: false, output: stdout, error: combined || `Process exited with code ${code}` });
         }
       });
 

--- a/electron.js
+++ b/electron.js
@@ -854,9 +854,9 @@ app.whenReady().then(() => {
 
   ipcMain.handle('renpy:generate-translations', async (event, sdkDir, projectPath, language) => {
     const executable = getRenpyExecutable(sdkDir);
-    if (!executable) throw new Error('Ren\'Py SDK path is not configured');
+    if (!executable) return { success: false, output: '', error: 'Ren\'Py SDK path is not configured' };
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       let stdout = '';
       let stderr = '';
       let settled = false;
@@ -866,7 +866,7 @@ app.whenReady().then(() => {
         if (settled) return;
         settled = true;
         proc.kill();
-        reject(new Error('Translation generation timed out after 60 seconds'));
+        resolve({ success: false, output: '', error: 'Translation generation timed out after 60 seconds' });
       }, 60000);
 
       proc.stdout.on('data', (data) => { stdout += data.toString(); });
@@ -879,7 +879,7 @@ app.whenReady().then(() => {
         if (code === 0) {
           resolve({ success: true, output: stdout });
         } else {
-          reject(new Error(stderr || `Process exited with code ${code}`));
+          resolve({ success: false, output: stdout, error: stderr || `Process exited with code ${code}` });
         }
       });
 
@@ -887,7 +887,7 @@ app.whenReady().then(() => {
         clearTimeout(timeout);
         if (settled) return;
         settled = true;
-        reject(new Error(`Failed to start Ren'Py: ${err.message}`));
+        resolve({ success: false, output: '', error: `Failed to start Ren'Py: ${err.message}` });
       });
     });
   });

--- a/electron.js
+++ b/electron.js
@@ -577,6 +577,10 @@ async function updateApplicationMenu() {
                 label: 'Stats',
                 click: (item, focusedWindow) => { if (focusedWindow) focusedWindow.webContents.send('menu-command', { command: 'open-static-tab', type: 'stats' }); }
             },
+            {
+                label: 'Translation Dashboard',
+                click: (item, focusedWindow) => { if (focusedWindow) focusedWindow.webContents.send('menu-command', { command: 'open-static-tab', type: 'translations' }); }
+            },
             { type: 'separator' },
             {
                 label: 'Toggle Left Sidebar',

--- a/hooks/useRenpyAnalysis.ts
+++ b/hooks/useRenpyAnalysis.ts
@@ -195,6 +195,13 @@ export const performRenpyAnalysis = (blocks: AnalysisBlock[]): RenpyAnalysisResu
     routeLinks: [],
     identifiedRoutes: [],
     routesTruncated: false,
+    translationData: {
+      translatableStrings: [],
+      translatedStrings: new Map(),
+      languageCoverages: [],
+      detectedLanguages: [],
+      stringTranslations: new Map(),
+    },
   };
 
   blocks.forEach(block => {
@@ -672,6 +679,13 @@ export const EMPTY_ANALYSIS_RESULT: RenpyAnalysisResult = {
   routeLinks: [],
   identifiedRoutes: [],
   routesTruncated: false,
+  translationData: {
+    translatableStrings: [],
+    translatedStrings: new Map(),
+    languageCoverages: [],
+    detectedLanguages: [],
+    stringTranslations: new Map(),
+  },
 };
 
 /** Module-level worker singleton — created once, reused across re-renders. */

--- a/lib/renpyTranslationParser.ts
+++ b/lib/renpyTranslationParser.ts
@@ -175,6 +175,21 @@ export function extractTranslatableStrings(
 }
 
 /**
+ * Derive the source file path from a translation file path by stripping the
+ * `tl/<lang>/` segment. For example:
+ *   `game/tl/french/script.rpy` → `game/script.rpy`
+ *   `game/tl/japanese/chapter1.rpy` → `game/chapter1.rpy`
+ */
+export function deriveSourceFilePath(translationFilePath: string, language: string): string {
+  // Normalize to forward slashes for matching
+  const normalized = translationFilePath.replace(/\\/g, '/');
+  const tlSegment = `tl/${language}/`;
+  const idx = normalized.indexOf(tlSegment);
+  if (idx === -1) return translationFilePath;
+  return normalized.slice(0, idx) + normalized.slice(idx + tlSegment.length);
+}
+
+/**
  * Extract translated strings from translation blocks (files under `/tl/<lang>/`).
  * Parses both `translate <lang> <id>:` blocks and `translate <lang> strings:` tables.
  */
@@ -219,6 +234,8 @@ export function extractTranslatedStrings(
                 filePath: block.filePath,
                 line: j + 1,
                 language: lang,
+                characterTag: null,
+                sourceText: currentOld,
               };
               if (!translatedStrings.has(lang)) translatedStrings.set(lang, []);
               translatedStrings.get(lang)!.push(entry);
@@ -245,14 +262,15 @@ export function extractTranslatedStrings(
           // Look for dialogue or narration in the translated block
           const diaMatch = innerLine.match(DIALOGUE_REGEX);
           if (diaMatch) {
-            const text = diaMatch[2];
             const entry: TranslatedString = {
               id,
-              translatedText: text,
+              translatedText: diaMatch[2],
               blockId: block.id,
               filePath: block.filePath,
               line: j + 1,
               language: lang,
+              characterTag: diaMatch[1],
+              sourceText: null,
             };
             if (!translatedStrings.has(lang)) translatedStrings.set(lang, []);
             translatedStrings.get(lang)!.push(entry);
@@ -261,14 +279,15 @@ export function extractTranslatedStrings(
 
           const narMatch = innerLine.match(NARRATION_REGEX);
           if (narMatch) {
-            const text = narMatch[1];
             const entry: TranslatedString = {
               id,
-              translatedText: text,
+              translatedText: narMatch[1],
               blockId: block.id,
               filePath: block.filePath,
               line: j + 1,
               language: lang,
+              characterTag: null,
+              sourceText: null,
             };
             if (!translatedStrings.has(lang)) translatedStrings.set(lang, []);
             translatedStrings.get(lang)!.push(entry);
@@ -284,11 +303,109 @@ export function extractTranslatedStrings(
 }
 
 /**
- * Compute per-language coverage statistics.
+ * Build a map from source string ID to Map<language, TranslatedString> by matching
+ * translations to source strings using file path derivation and text/structure matching.
+ *
+ * This is the core matching logic. Ren'Py translation block IDs (`label_md5hash`)
+ * don't match our source string IDs (`blockId:lineNumber`), so we match by:
+ * 1. Deriving the source file path from the translation file path
+ * 2. Grouping source strings by file, character tag, and type
+ * 3. Matching translations to sources by file + character tag + text content
+ * 4. For string tables (menu choices): matching by the `old` text stored in sourceText
+ */
+export function buildStringTranslationMap(
+  translatableStrings: TranslatableString[],
+  translatedStrings: Map<string, TranslatedString[]>,
+  detectedLanguages: Set<string>,
+): Map<string, Map<string, TranslatedString>> {
+  const stringTranslations = new Map<string, Map<string, TranslatedString>>();
+
+  // Group source strings by file path for efficient lookup
+  const sourceByFile = new Map<string, TranslatableString[]>();
+  for (const s of translatableStrings) {
+    const normalized = s.filePath.replace(/\\/g, '/');
+    if (!sourceByFile.has(normalized)) sourceByFile.set(normalized, []);
+    sourceByFile.get(normalized)!.push(s);
+  }
+
+  for (const lang of detectedLanguages) {
+    const langTranslations = translatedStrings.get(lang) || [];
+    const claimed = new Set<string>(); // source string IDs already matched
+
+    for (const ts of langTranslations) {
+      // String table entries (menu choices) — match by old text
+      if (ts.id.startsWith('strings:') && ts.sourceText) {
+        // Find a source string whose text matches the old text
+        for (const sources of sourceByFile.values()) {
+          for (const src of sources) {
+            if (!claimed.has(src.id) && src.sourceText === ts.sourceText) {
+              claimed.add(src.id);
+              if (!stringTranslations.has(src.id)) stringTranslations.set(src.id, new Map());
+              stringTranslations.get(src.id)!.set(lang, ts);
+              break;
+            }
+          }
+        }
+        continue;
+      }
+
+      // Block translations — derive source file from translation file path
+      const derivedSourcePath = deriveSourceFilePath(ts.filePath, lang);
+      const fileSourceStrings = sourceByFile.get(derivedSourcePath);
+      if (!fileSourceStrings) continue;
+
+      // Find a matching source string in the same file
+      let matched = false;
+      for (const src of fileSourceStrings) {
+        if (claimed.has(src.id)) continue;
+
+        // Match by character tag + text for stale translations (text is identical to source)
+        const isStale = ts.translatedText === src.sourceText;
+
+        // Match by character tag alignment
+        const tagMatches = ts.characterTag === src.characterTag;
+        // For narration, both should have null character tag
+        const isNarrationMatch = ts.characterTag === null && src.characterTag === null && src.type === 'narration';
+
+        if (isStale && (tagMatches || isNarrationMatch)) {
+          claimed.add(src.id);
+          if (!stringTranslations.has(src.id)) stringTranslations.set(src.id, new Map());
+          stringTranslations.get(src.id)!.set(lang, ts);
+          matched = true;
+          break;
+        }
+      }
+
+      if (matched) continue;
+
+      // Non-stale: match by character tag + type within the same file
+      // Ren'Py translation blocks appear in the same order as source strings,
+      // so matching the first unclaimed source string with the right tag works.
+      for (const src of fileSourceStrings) {
+        if (claimed.has(src.id)) continue;
+
+        const tagMatches = ts.characterTag === src.characterTag;
+        const isNarrationMatch = ts.characterTag === null && src.characterTag === null && src.type === 'narration';
+
+        if (tagMatches || isNarrationMatch) {
+          claimed.add(src.id);
+          if (!stringTranslations.has(src.id)) stringTranslations.set(src.id, new Map());
+          stringTranslations.get(src.id)!.set(lang, ts);
+          break;
+        }
+      }
+    }
+  }
+
+  return stringTranslations;
+}
+
+/**
+ * Compute per-language coverage statistics from the matched string translation map.
  */
 export function computeLanguageCoverages(
   translatableStrings: TranslatableString[],
-  translatedStrings: Map<string, TranslatedString[]>,
+  stringTranslations: Map<string, Map<string, TranslatedString>>,
   detectedLanguages: Set<string>,
 ): LanguageCoverage[] {
   const totalStrings = translatableStrings.length;
@@ -303,24 +420,20 @@ export function computeLanguageCoverages(
   const coverages: LanguageCoverage[] = [];
 
   for (const lang of detectedLanguages) {
-    const langStrings = translatedStrings.get(lang) || [];
-    const translatedIds = new Set(langStrings.map(s => s.id));
-
-    // Count translated — match by translation block ID to source string IDs
-    // Simple heuristic: count how many unique IDs exist in the translation
-    const translatedCount = Math.min(translatedIds.size, totalStrings);
-
-    // Stale detection: translations whose text matches the source exactly
-    const sourceTextMap = new Map(translatableStrings.map(s => [s.sourceText, s]));
+    let translatedCount = 0;
     let staleCount = 0;
-    for (const ts of langStrings) {
-      if (sourceTextMap.has(ts.translatedText) && ts.translatedText === sourceTextMap.get(ts.translatedText)!.sourceText) {
-        staleCount++;
+
+    for (const src of translatableStrings) {
+      const translations = stringTranslations.get(src.id);
+      const t = translations?.get(lang);
+      if (t) {
+        translatedCount++;
+        if (t.translatedText === src.sourceText) {
+          staleCount++;
+        }
       }
     }
 
-    // Stale strings have a translation entry but the text is identical to the source,
-    // so they shouldn't count toward completion — they're just untranslated placeholders.
     const effectiveTranslated = translatedCount - staleCount;
     const untranslatedCount = totalStrings - translatedCount;
     const completionPercent = totalStrings > 0 ? Math.round((effectiveTranslated / totalStrings) * 100) : 0;
@@ -329,15 +442,14 @@ export function computeLanguageCoverages(
     const fileBreakdown: TranslationFileBreakdown[] = [];
     for (const [filePath, fileStrings] of stringsByFile) {
       const fileTotal = fileStrings.length;
-      // Check how many of this file's strings have translations
       let fileTranslated = 0;
       let fileStale = 0;
       for (const s of fileStrings) {
-        // Check if any translation id matches patterns for this source string
-        const matchingTranslation = langStrings.find(t => t.id === s.id || t.translatedText === s.sourceText);
-        if (matchingTranslation) {
+        const translations = stringTranslations.get(s.id);
+        const t = translations?.get(lang);
+        if (t) {
           fileTranslated++;
-          if (matchingTranslation.translatedText === s.sourceText) {
+          if (t.translatedText === s.sourceText) {
             fileStale++;
           }
         }
@@ -362,7 +474,6 @@ export function computeLanguageCoverages(
     });
   }
 
-  // Sort by language name
   coverages.sort((a, b) => a.language.localeCompare(b.language));
 
   return coverages;
@@ -378,16 +489,10 @@ export function performTranslationAnalysis(
 ): TranslationAnalysisResult {
   const translatableStrings = extractTranslatableStrings(blocks, dialogueLines, labels);
   const { translatedStrings, detectedLanguages } = extractTranslatedStrings(blocks);
-  const languageCoverages = computeLanguageCoverages(translatableStrings, translatedStrings, detectedLanguages);
 
-  // Build a lookup: sourceStringId -> Map<language, TranslatedString>
-  const stringTranslations = new Map<string, Map<string, TranslatedString>>();
-  for (const [lang, strings] of translatedStrings) {
-    for (const ts of strings) {
-      if (!stringTranslations.has(ts.id)) stringTranslations.set(ts.id, new Map());
-      stringTranslations.get(ts.id)!.set(lang, ts);
-    }
-  }
+  // Build the matched source→translation map FIRST, then derive coverages from it
+  const stringTranslations = buildStringTranslationMap(translatableStrings, translatedStrings, detectedLanguages);
+  const languageCoverages = computeLanguageCoverages(translatableStrings, stringTranslations, detectedLanguages);
 
   return {
     translatableStrings,

--- a/lib/renpyTranslationParser.ts
+++ b/lib/renpyTranslationParser.ts
@@ -319,8 +319,11 @@ export function computeLanguageCoverages(
       }
     }
 
+    // Stale strings have a translation entry but the text is identical to the source,
+    // so they shouldn't count toward completion — they're just untranslated placeholders.
+    const effectiveTranslated = translatedCount - staleCount;
     const untranslatedCount = totalStrings - translatedCount;
-    const completionPercent = totalStrings > 0 ? Math.round((translatedCount / totalStrings) * 100) : 0;
+    const completionPercent = totalStrings > 0 ? Math.round((effectiveTranslated / totalStrings) * 100) : 0;
 
     // File breakdown
     const fileBreakdown: TranslationFileBreakdown[] = [];
@@ -344,7 +347,7 @@ export function computeLanguageCoverages(
         totalStrings: fileTotal,
         translatedCount: fileTranslated,
         staleCount: fileStale,
-        completionPercent: fileTotal > 0 ? Math.round((fileTranslated / fileTotal) * 100) : 0,
+        completionPercent: fileTotal > 0 ? Math.round(((fileTranslated - fileStale) / fileTotal) * 100) : 0,
       });
     }
 

--- a/lib/renpyTranslationParser.ts
+++ b/lib/renpyTranslationParser.ts
@@ -1,0 +1,396 @@
+/**
+ * @file renpyTranslationParser.ts
+ * @description Pure functions for parsing Ren'Py translation blocks and computing
+ * per-language translation coverage. Works with the existing block/analysis data
+ * produced by useRenpyAnalysis.
+ */
+
+import type {
+  TranslatableString,
+  TranslatedString,
+  LanguageCoverage,
+  TranslationFileBreakdown,
+  TranslationAnalysisResult,
+  DialogueLine,
+} from '../types';
+
+// ---------------------------------------------------------------------------
+// Regex patterns
+// ---------------------------------------------------------------------------
+
+/** Matches `translate <lang> <id>:` blocks */
+const TRANSLATE_BLOCK_REGEX = /^\s*translate\s+([a-zA-Z0-9_]+)\s+([a-zA-Z0-9_]+)\s*:/;
+
+/** Matches `translate <lang> strings:` string-table blocks */
+const TRANSLATE_STRINGS_REGEX = /^\s*translate\s+([a-zA-Z0-9_]+)\s+strings\s*:/;
+
+/** Matches `old "..."` and `new "..."` lines inside a string-table block */
+const OLD_NEW_REGEX = /^\s*(old|new)\s+"((?:\\.|[^"\\])*)"/;
+
+/** Extracts language from a `/tl/<lang>/` path segment */
+const TL_PATH_REGEX = /[/\\]tl[/\\]([a-zA-Z0-9_]+)[/\\]/;
+
+/** Dialogue: `character "text"` */
+const DIALOGUE_REGEX = /^\s*([a-zA-Z0-9_]+)\s+"((?:\\.|[^"\\])*)"/;
+
+/** Narration: `"text"` (not starting with colon) */
+const NARRATION_REGEX = /^\s*"((?:\\.|[^"\\])*)"/;
+
+/** Menu choice: `"text"` followed by optional condition, ending with `:` */
+const MENU_CHOICE_REGEX = /^\s*"((?:\\.|[^"\\])*)"(?:\s+if\s+.+)?\s*:/;
+
+/** Label definition */
+const LABEL_REGEX = /^\s*label\s+([a-zA-Z0-9_]+):/;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface AnalysisBlock {
+  id: string;
+  content: string;
+  filePath: string;
+}
+
+/**
+ * Returns true if the file path looks like a Ren'Py translation file
+ * (i.e. it lives under a `/tl/<language>/` directory).
+ */
+export function isTranslationFile(filePath: string): boolean {
+  return TL_PATH_REGEX.test(filePath);
+}
+
+/**
+ * Extract the language code from a translation file path.
+ * Returns null if the path doesn't match the tl pattern.
+ */
+export function extractLanguageFromPath(filePath: string): string | null {
+  const m = filePath.match(TL_PATH_REGEX);
+  return m ? m[1] : null;
+}
+
+/**
+ * Extract translatable strings (dialogue, narration, menu choices) from source blocks.
+ */
+export function extractTranslatableStrings(
+  blocks: AnalysisBlock[],
+  dialogueLines: Map<string, DialogueLine[]>,
+  labels: Record<string, { blockId: string }>,
+): TranslatableString[] {
+  const strings: TranslatableString[] = [];
+  // Build a reverse map: blockId -> label names defined in it
+  const blockLabels = new Map<string, string[]>();
+  for (const [labelName, loc] of Object.entries(labels)) {
+    const existing = blockLabels.get(loc.blockId) || [];
+    existing.push(labelName);
+    blockLabels.set(loc.blockId, existing);
+  }
+
+  for (const block of blocks) {
+    // Skip translation files — we only want source strings
+    if (isTranslationFile(block.filePath)) continue;
+
+    const lines = block.content.split('\n');
+    let currentLabel: string | null = null;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const lineNum = i + 1;
+
+      // Track label scope
+      const labelMatch = line.match(LABEL_REGEX);
+      if (labelMatch) {
+        currentLabel = labelMatch[1];
+        continue;
+      }
+
+      // Menu choice
+      const menuMatch = line.match(MENU_CHOICE_REGEX);
+      if (menuMatch) {
+        const text = menuMatch[1];
+        if (text.trim()) {
+          strings.push({
+            id: `${block.id}:${lineNum}`,
+            sourceText: text,
+            blockId: block.id,
+            filePath: block.filePath,
+            line: lineNum,
+            labelScope: currentLabel,
+            characterTag: null,
+            type: 'menu-choice',
+          });
+        }
+        continue;
+      }
+
+      // Dialogue: character "text"
+      const diaMatch = line.match(DIALOGUE_REGEX);
+      if (diaMatch) {
+        const tag = diaMatch[1];
+        const text = diaMatch[2];
+        // Only count as dialogue if the tag is known or looks like a character
+        // (exclude Ren'Py keywords that might match the pattern)
+        const KEYWORDS = new Set([
+          'label', 'jump', 'call', 'return', 'menu', 'if', 'elif', 'else',
+          'while', 'for', 'pass', 'python', 'init', 'define', 'default',
+          'screen', 'show', 'hide', 'scene', 'with', 'play', 'stop', 'queue',
+          'pause', 'image', 'transform', 'translate', 'style', 'window',
+        ]);
+        if (!KEYWORDS.has(tag) && text.trim()) {
+          strings.push({
+            id: `${block.id}:${lineNum}`,
+            sourceText: text,
+            blockId: block.id,
+            filePath: block.filePath,
+            line: lineNum,
+            labelScope: currentLabel,
+            characterTag: tag,
+            type: 'dialogue',
+          });
+        }
+        continue;
+      }
+
+      // Narration: "text"
+      const narMatch = line.match(NARRATION_REGEX);
+      if (narMatch) {
+        const text = narMatch[1];
+        if (text.trim()) {
+          strings.push({
+            id: `${block.id}:${lineNum}`,
+            sourceText: text,
+            blockId: block.id,
+            filePath: block.filePath,
+            line: lineNum,
+            labelScope: currentLabel,
+            characterTag: null,
+            type: 'narration',
+          });
+        }
+      }
+    }
+  }
+
+  return strings;
+}
+
+/**
+ * Extract translated strings from translation blocks (files under `/tl/<lang>/`).
+ * Parses both `translate <lang> <id>:` blocks and `translate <lang> strings:` tables.
+ */
+export function extractTranslatedStrings(
+  blocks: AnalysisBlock[],
+): { translatedStrings: Map<string, TranslatedString[]>; detectedLanguages: Set<string> } {
+  const translatedStrings = new Map<string, TranslatedString[]>();
+  const detectedLanguages = new Set<string>();
+
+  for (const block of blocks) {
+    if (!isTranslationFile(block.filePath)) continue;
+
+    const langFromPath = extractLanguageFromPath(block.filePath);
+    if (langFromPath) detectedLanguages.add(langFromPath);
+
+    const lines = block.content.split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      // translate <lang> strings: (check BEFORE translate <lang> <id>: since "strings" matches both)
+      const stringsMatch = line.match(TRANSLATE_STRINGS_REGEX);
+      if (stringsMatch) {
+        const lang = stringsMatch[1];
+        detectedLanguages.add(lang);
+
+        let currentOld: string | null = null;
+        for (let j = i + 1; j < lines.length; j++) {
+          const innerLine = lines[j];
+          if (innerLine.trim() === '') continue;
+          if (!/^\s/.test(innerLine)) break;
+
+          const oldNewMatch = innerLine.match(OLD_NEW_REGEX);
+          if (oldNewMatch) {
+            if (oldNewMatch[1] === 'old') {
+              currentOld = oldNewMatch[2];
+            } else if (oldNewMatch[1] === 'new' && currentOld !== null) {
+              const entryId = `strings:${currentOld}`;
+              const entry: TranslatedString = {
+                id: entryId,
+                translatedText: oldNewMatch[2],
+                blockId: block.id,
+                filePath: block.filePath,
+                line: j + 1,
+                language: lang,
+              };
+              if (!translatedStrings.has(lang)) translatedStrings.set(lang, []);
+              translatedStrings.get(lang)!.push(entry);
+              currentOld = null;
+            }
+          }
+        }
+        continue;
+      }
+
+      // translate <lang> <id>:
+      const blockMatch = line.match(TRANSLATE_BLOCK_REGEX);
+      if (blockMatch) {
+        const lang = blockMatch[1];
+        const id = blockMatch[2];
+        detectedLanguages.add(lang);
+
+        // Look for the translated text in subsequent lines
+        for (let j = i + 1; j < lines.length; j++) {
+          const innerLine = lines[j];
+          if (innerLine.trim() === '') continue;
+          if (!/^\s/.test(innerLine)) break;
+
+          // Look for dialogue or narration in the translated block
+          const diaMatch = innerLine.match(DIALOGUE_REGEX);
+          if (diaMatch) {
+            const text = diaMatch[2];
+            const entry: TranslatedString = {
+              id,
+              translatedText: text,
+              blockId: block.id,
+              filePath: block.filePath,
+              line: j + 1,
+              language: lang,
+            };
+            if (!translatedStrings.has(lang)) translatedStrings.set(lang, []);
+            translatedStrings.get(lang)!.push(entry);
+            break;
+          }
+
+          const narMatch = innerLine.match(NARRATION_REGEX);
+          if (narMatch) {
+            const text = narMatch[1];
+            const entry: TranslatedString = {
+              id,
+              translatedText: text,
+              blockId: block.id,
+              filePath: block.filePath,
+              line: j + 1,
+              language: lang,
+            };
+            if (!translatedStrings.has(lang)) translatedStrings.set(lang, []);
+            translatedStrings.get(lang)!.push(entry);
+            break;
+          }
+        }
+        continue;
+      }
+    }
+  }
+
+  return { translatedStrings, detectedLanguages };
+}
+
+/**
+ * Compute per-language coverage statistics.
+ */
+export function computeLanguageCoverages(
+  translatableStrings: TranslatableString[],
+  translatedStrings: Map<string, TranslatedString[]>,
+  detectedLanguages: Set<string>,
+): LanguageCoverage[] {
+  const totalStrings = translatableStrings.length;
+
+  // Group source strings by file for file breakdown
+  const stringsByFile = new Map<string, TranslatableString[]>();
+  for (const s of translatableStrings) {
+    if (!stringsByFile.has(s.filePath)) stringsByFile.set(s.filePath, []);
+    stringsByFile.get(s.filePath)!.push(s);
+  }
+
+  const coverages: LanguageCoverage[] = [];
+
+  for (const lang of detectedLanguages) {
+    const langStrings = translatedStrings.get(lang) || [];
+    const translatedIds = new Set(langStrings.map(s => s.id));
+
+    // Count translated — match by translation block ID to source string IDs
+    // Simple heuristic: count how many unique IDs exist in the translation
+    const translatedCount = Math.min(translatedIds.size, totalStrings);
+
+    // Stale detection: translations whose text matches the source exactly
+    const sourceTextMap = new Map(translatableStrings.map(s => [s.sourceText, s]));
+    let staleCount = 0;
+    for (const ts of langStrings) {
+      if (sourceTextMap.has(ts.translatedText) && ts.translatedText === sourceTextMap.get(ts.translatedText)!.sourceText) {
+        staleCount++;
+      }
+    }
+
+    const untranslatedCount = totalStrings - translatedCount;
+    const completionPercent = totalStrings > 0 ? Math.round((translatedCount / totalStrings) * 100) : 0;
+
+    // File breakdown
+    const fileBreakdown: TranslationFileBreakdown[] = [];
+    for (const [filePath, fileStrings] of stringsByFile) {
+      const fileTotal = fileStrings.length;
+      // Check how many of this file's strings have translations
+      let fileTranslated = 0;
+      let fileStale = 0;
+      for (const s of fileStrings) {
+        // Check if any translation id matches patterns for this source string
+        const matchingTranslation = langStrings.find(t => t.id === s.id || t.translatedText === s.sourceText);
+        if (matchingTranslation) {
+          fileTranslated++;
+          if (matchingTranslation.translatedText === s.sourceText) {
+            fileStale++;
+          }
+        }
+      }
+      fileBreakdown.push({
+        sourceFilePath: filePath,
+        totalStrings: fileTotal,
+        translatedCount: fileTranslated,
+        staleCount: fileStale,
+        completionPercent: fileTotal > 0 ? Math.round((fileTranslated / fileTotal) * 100) : 0,
+      });
+    }
+
+    coverages.push({
+      language: lang,
+      totalStrings,
+      translatedCount,
+      staleCount,
+      untranslatedCount,
+      completionPercent,
+      fileBreakdown,
+    });
+  }
+
+  // Sort by language name
+  coverages.sort((a, b) => a.language.localeCompare(b.language));
+
+  return coverages;
+}
+
+/**
+ * Main entry point: run a full translation analysis over the given blocks.
+ */
+export function performTranslationAnalysis(
+  blocks: AnalysisBlock[],
+  dialogueLines: Map<string, DialogueLine[]>,
+  labels: Record<string, { blockId: string }>,
+): TranslationAnalysisResult {
+  const translatableStrings = extractTranslatableStrings(blocks, dialogueLines, labels);
+  const { translatedStrings, detectedLanguages } = extractTranslatedStrings(blocks);
+  const languageCoverages = computeLanguageCoverages(translatableStrings, translatedStrings, detectedLanguages);
+
+  // Build a lookup: sourceStringId -> Map<language, TranslatedString>
+  const stringTranslations = new Map<string, Map<string, TranslatedString>>();
+  for (const [lang, strings] of translatedStrings) {
+    for (const ts of strings) {
+      if (!stringTranslations.has(ts.id)) stringTranslations.set(ts.id, new Map());
+      stringTranslations.get(ts.id)!.set(lang, ts);
+    }
+  }
+
+  return {
+    translatableStrings,
+    translatedStrings,
+    languageCoverages,
+    detectedLanguages: Array.from(detectedLanguages).sort(),
+    stringTranslations,
+  };
+}

--- a/preload.js
+++ b/preload.js
@@ -61,6 +61,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   runGame: (renpyPath, projectPath) => ipcRenderer.send('game:run', renpyPath, projectPath),
   stopGame: () => ipcRenderer.send('game:stop'),
   checkRenpyPath: (path) => ipcRenderer.invoke('renpy:check-path', path),
+  generateTranslations: (sdkDir, projectPath, language) => ipcRenderer.invoke('renpy:generate-translations', sdkDir, projectPath, language),
   onGameStarted: (callback) => {
     const subscription = () => callback();
     ipcRenderer.on('game-started', subscription);

--- a/test/TranslationDashboard.test.tsx
+++ b/test/TranslationDashboard.test.tsx
@@ -16,6 +16,12 @@ beforeAll(() => {
 // Helpers
 // ---------------------------------------------------------------------------
 
+const defaultGenerateProps = {
+  onGenerateTranslations: vi.fn().mockResolvedValue(undefined),
+  isGenerating: false,
+  isRenpyPathValid: true,
+};
+
 function makeEmptyTranslationData(): TranslationAnalysisResult {
   return {
     translatableStrings: [],
@@ -80,7 +86,7 @@ describe('TranslationDashboard', () => {
   it('renders empty state when no languages detected', () => {
     const data = makeEmptyTranslationData();
     render(
-      <TranslationDashboard translationData={data} blocks={[]} onOpenBlock={vi.fn()} />,
+      <TranslationDashboard translationData={data} blocks={[]} onOpenBlock={vi.fn()} {...defaultGenerateProps} />,
     );
     expect(screen.getByText('No Translations Detected')).toBeInTheDocument();
   });
@@ -88,7 +94,7 @@ describe('TranslationDashboard', () => {
   it('renders language cards with correct percentages', () => {
     const data = makeSampleTranslationData();
     render(
-      <TranslationDashboard translationData={data} blocks={makeSampleBlocks()} onOpenBlock={vi.fn()} />,
+      <TranslationDashboard translationData={data} blocks={makeSampleBlocks()} onOpenBlock={vi.fn()} {...defaultGenerateProps} />,
     );
     expect(screen.getAllByText('french').length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText('50%').length).toBeGreaterThanOrEqual(1);
@@ -98,7 +104,7 @@ describe('TranslationDashboard', () => {
   it('renders file breakdown table', () => {
     const data = makeSampleTranslationData();
     render(
-      <TranslationDashboard translationData={data} blocks={makeSampleBlocks()} onOpenBlock={vi.fn()} />,
+      <TranslationDashboard translationData={data} blocks={makeSampleBlocks()} onOpenBlock={vi.fn()} {...defaultGenerateProps} />,
     );
     expect(screen.getByText('game/script.rpy')).toBeInTheDocument();
   });
@@ -106,7 +112,7 @@ describe('TranslationDashboard', () => {
   it('renders translatable strings section', () => {
     const data = makeSampleTranslationData();
     render(
-      <TranslationDashboard translationData={data} blocks={makeSampleBlocks()} onOpenBlock={vi.fn()} />,
+      <TranslationDashboard translationData={data} blocks={makeSampleBlocks()} onOpenBlock={vi.fn()} {...defaultGenerateProps} />,
     );
     expect(screen.getByText(/Translatable Strings/)).toBeInTheDocument();
   });
@@ -115,7 +121,7 @@ describe('TranslationDashboard', () => {
     const onOpenBlock = vi.fn();
     const data = makeSampleTranslationData();
     render(
-      <TranslationDashboard translationData={data} blocks={makeSampleBlocks()} onOpenBlock={onOpenBlock} />,
+      <TranslationDashboard translationData={data} blocks={makeSampleBlocks()} onOpenBlock={onOpenBlock} {...defaultGenerateProps} />,
     );
     const row = screen.getByTestId('string-row-0');
     fireEvent.click(row);
@@ -125,7 +131,7 @@ describe('TranslationDashboard', () => {
   it('filters by status pill', () => {
     const data = makeSampleTranslationData();
     render(
-      <TranslationDashboard translationData={data} blocks={makeSampleBlocks()} onOpenBlock={vi.fn()} />,
+      <TranslationDashboard translationData={data} blocks={makeSampleBlocks()} onOpenBlock={vi.fn()} {...defaultGenerateProps} />,
     );
     // Click "untranslated" status pill — there are two sets (file breakdown + shared),
     // just click the first occurrence
@@ -133,5 +139,89 @@ describe('TranslationDashboard', () => {
     fireEvent.click(untranslatedButtons[0]);
     // After filtering, the string count should reflect untranslated only
     expect(screen.getByText(/Translatable Strings \(1\)/)).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Generate Translations tests
+  // ---------------------------------------------------------------------------
+
+  it('renders generate button in empty state when isRenpyPathValid is true', () => {
+    const data = makeEmptyTranslationData();
+    render(
+      <TranslationDashboard translationData={data} blocks={[]} onOpenBlock={vi.fn()} {...defaultGenerateProps} />,
+    );
+    const btn = screen.getByTestId('generate-translations-btn');
+    expect(btn).toBeInTheDocument();
+    expect(btn).not.toBeDisabled();
+  });
+
+  it('disables generate button when isRenpyPathValid is false', () => {
+    const data = makeEmptyTranslationData();
+    render(
+      <TranslationDashboard translationData={data} blocks={[]} onOpenBlock={vi.fn()} {...defaultGenerateProps} isRenpyPathValid={false} />,
+    );
+    const btn = screen.getByTestId('generate-translations-btn');
+    expect(btn).toBeDisabled();
+  });
+
+  it('disables generate button when isGenerating is true', () => {
+    const data = makeEmptyTranslationData();
+    render(
+      <TranslationDashboard translationData={data} blocks={[]} onOpenBlock={vi.fn()} {...defaultGenerateProps} isGenerating={true} />,
+    );
+    const btn = screen.getByTestId('generate-translations-btn');
+    expect(btn).toBeDisabled();
+    expect(screen.getByText('Generating...')).toBeInTheDocument();
+  });
+
+  it('shows language input form when generate button is clicked', () => {
+    const data = makeEmptyTranslationData();
+    render(
+      <TranslationDashboard translationData={data} blocks={[]} onOpenBlock={vi.fn()} {...defaultGenerateProps} />,
+    );
+    fireEvent.click(screen.getByTestId('generate-translations-btn'));
+    expect(screen.getByTestId('generate-form')).toBeInTheDocument();
+    expect(screen.getByTestId('language-input')).toBeInTheDocument();
+    expect(screen.getByTestId('confirm-generate-btn')).toBeInTheDocument();
+    expect(screen.getByTestId('cancel-generate-btn')).toBeInTheDocument();
+  });
+
+  it('validates language input — rejects invalid, accepts valid', () => {
+    const data = makeEmptyTranslationData();
+    render(
+      <TranslationDashboard translationData={data} blocks={[]} onOpenBlock={vi.fn()} {...defaultGenerateProps} />,
+    );
+    fireEvent.click(screen.getByTestId('generate-translations-btn'));
+
+    const input = screen.getByTestId('language-input');
+    const confirmBtn = screen.getByTestId('confirm-generate-btn');
+
+    // Empty input → confirm disabled
+    expect(confirmBtn).toBeDisabled();
+
+    // Invalid input (starts with number)
+    fireEvent.change(input, { target: { value: '1french' } });
+    expect(confirmBtn).toBeDisabled();
+    expect(screen.getByTestId('language-validation-error')).toBeInTheDocument();
+
+    // Valid input
+    fireEvent.change(input, { target: { value: 'french' } });
+    expect(confirmBtn).not.toBeDisabled();
+    expect(screen.queryByTestId('language-validation-error')).not.toBeInTheDocument();
+  });
+
+  it('calls onGenerateTranslations with entered language on confirm', () => {
+    const onGenerate = vi.fn().mockResolvedValue(undefined);
+    const data = makeEmptyTranslationData();
+    render(
+      <TranslationDashboard translationData={data} blocks={[]} onOpenBlock={vi.fn()} {...defaultGenerateProps} onGenerateTranslations={onGenerate} />,
+    );
+    fireEvent.click(screen.getByTestId('generate-translations-btn'));
+
+    const input = screen.getByTestId('language-input');
+    fireEvent.change(input, { target: { value: 'japanese' } });
+    fireEvent.click(screen.getByTestId('confirm-generate-btn'));
+
+    expect(onGenerate).toHaveBeenCalledWith('japanese');
   });
 });

--- a/test/TranslationDashboard.test.tsx
+++ b/test/TranslationDashboard.test.tsx
@@ -109,6 +109,47 @@ describe('TranslationDashboard', () => {
     expect(screen.getByText('game/script.rpy')).toBeInTheDocument();
   });
 
+  it('shows effective translated and untranslated counts in file breakdown when stale entries exist', () => {
+    const data: TranslationAnalysisResult = {
+      translatableStrings: [],
+      translatedStrings: new Map(),
+      languageCoverages: [
+        {
+          language: 'french',
+          totalStrings: 912,
+          translatedCount: 912,
+          staleCount: 911,
+          untranslatedCount: 0,
+          completionPercent: 0,
+          fileBreakdown: [
+            {
+              sourceFilePath: 'game/script.rpy',
+              totalStrings: 912,
+              translatedCount: 912,
+              staleCount: 911,
+              completionPercent: 0,
+            },
+          ],
+        },
+      ],
+      detectedLanguages: ['french'],
+      stringTranslations: new Map(),
+    };
+
+    const { container } = render(
+      <TranslationDashboard translationData={data} blocks={[]} onOpenBlock={vi.fn()} {...defaultGenerateProps} />,
+    );
+
+    const row = container.querySelector('tbody tr');
+    expect(row).not.toBeNull();
+    const cells = row!.querySelectorAll('td');
+    expect(cells[1]).toHaveTextContent('912');
+    expect(cells[2]).toHaveTextContent('1');
+    expect(cells[3]).toHaveTextContent('911');
+    expect(cells[4]).toHaveTextContent('911');
+    expect(cells[5]).toHaveTextContent('0%');
+  });
+
   it('renders translatable strings section', () => {
     const data = makeSampleTranslationData();
     render(
@@ -138,6 +179,19 @@ describe('TranslationDashboard', () => {
     const untranslatedButtons = screen.getAllByText('untranslated');
     fireEvent.click(untranslatedButtons[0]);
     // After filtering, the string count should reflect untranslated only
+    expect(screen.getByText(/Translatable Strings \(1\)/)).toBeInTheDocument();
+  });
+
+  it('shows partially translated files when filtering by translated status', () => {
+    const data = makeSampleTranslationData();
+    render(
+      <TranslationDashboard translationData={data} blocks={makeSampleBlocks()} onOpenBlock={vi.fn()} {...defaultGenerateProps} />,
+    );
+
+    const translatedButtons = screen.getAllByText('translated');
+    fireEvent.click(translatedButtons[0]);
+
+    expect(screen.getByText('game/script.rpy')).toBeInTheDocument();
     expect(screen.getByText(/Translatable Strings \(1\)/)).toBeInTheDocument();
   });
 
@@ -174,13 +228,15 @@ describe('TranslationDashboard', () => {
     expect(screen.getByText('Generating...')).toBeInTheDocument();
   });
 
-  it('shows language input form when generate button is clicked', () => {
+  it('shows generate language modal when generate button is clicked', () => {
     const data = makeEmptyTranslationData();
     render(
       <TranslationDashboard translationData={data} blocks={[]} onOpenBlock={vi.fn()} {...defaultGenerateProps} />,
     );
     fireEvent.click(screen.getByTestId('generate-translations-btn'));
+    expect(screen.getByTestId('generate-modal')).toBeInTheDocument();
     expect(screen.getByTestId('generate-form')).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByTestId('language-input')).toBeInTheDocument();
     expect(screen.getByTestId('confirm-generate-btn')).toBeInTheDocument();
     expect(screen.getByTestId('cancel-generate-btn')).toBeInTheDocument();

--- a/test/TranslationDashboard.test.tsx
+++ b/test/TranslationDashboard.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TranslationDashboard from '../components/TranslationDashboard';
+import type { TranslationAnalysisResult, Block } from '../types';
+
+// ResizeObserver is not available in jsdom — provide a minimal stub.
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEmptyTranslationData(): TranslationAnalysisResult {
+  return {
+    translatableStrings: [],
+    translatedStrings: new Map(),
+    languageCoverages: [],
+    detectedLanguages: [],
+    stringTranslations: new Map(),
+  };
+}
+
+function makeSampleTranslationData(): TranslationAnalysisResult {
+  const stringTranslations = new Map();
+  stringTranslations.set('id1', new Map([
+    ['french', { id: 'id1', translatedText: 'Bonjour', blockId: 'tl1', filePath: 'game/tl/french/script.rpy', line: 2, language: 'french' }],
+  ]));
+
+  return {
+    translatableStrings: [
+      { id: 'id1', sourceText: 'Hello', blockId: 'b1', filePath: 'game/script.rpy', line: 1, labelScope: 'start', characterTag: 'e', type: 'dialogue' },
+      { id: 'id2', sourceText: 'Goodbye', blockId: 'b1', filePath: 'game/script.rpy', line: 2, labelScope: 'start', characterTag: 'e', type: 'dialogue' },
+    ],
+    translatedStrings: new Map([
+      ['french', [{ id: 'id1', translatedText: 'Bonjour', blockId: 'tl1', filePath: 'game/tl/french/script.rpy', line: 2, language: 'french' }]],
+    ]),
+    languageCoverages: [
+      {
+        language: 'french',
+        totalStrings: 2,
+        translatedCount: 1,
+        staleCount: 0,
+        untranslatedCount: 1,
+        completionPercent: 50,
+        fileBreakdown: [
+          { sourceFilePath: 'game/script.rpy', totalStrings: 2, translatedCount: 1, staleCount: 0, completionPercent: 50 },
+        ],
+      },
+    ],
+    detectedLanguages: ['french'],
+    stringTranslations,
+  };
+}
+
+function makeSampleBlocks(): Block[] {
+  return [
+    {
+      id: 'b1',
+      content: 'label start:\n    e "Hello"\n    e "Goodbye"\n',
+      position: { x: 0, y: 0 },
+      width: 200,
+      height: 150,
+      title: 'start',
+      filePath: 'game/script.rpy',
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TranslationDashboard', () => {
+  it('renders empty state when no languages detected', () => {
+    const data = makeEmptyTranslationData();
+    render(
+      <TranslationDashboard translationData={data} blocks={[]} onOpenBlock={vi.fn()} />,
+    );
+    expect(screen.getByText('No Translations Detected')).toBeInTheDocument();
+  });
+
+  it('renders language cards with correct percentages', () => {
+    const data = makeSampleTranslationData();
+    render(
+      <TranslationDashboard translationData={data} blocks={makeSampleBlocks()} onOpenBlock={vi.fn()} />,
+    );
+    expect(screen.getAllByText('french').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('50%').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('1/2')).toBeInTheDocument();
+  });
+
+  it('renders file breakdown table', () => {
+    const data = makeSampleTranslationData();
+    render(
+      <TranslationDashboard translationData={data} blocks={makeSampleBlocks()} onOpenBlock={vi.fn()} />,
+    );
+    expect(screen.getByText('game/script.rpy')).toBeInTheDocument();
+  });
+
+  it('renders translatable strings section', () => {
+    const data = makeSampleTranslationData();
+    render(
+      <TranslationDashboard translationData={data} blocks={makeSampleBlocks()} onOpenBlock={vi.fn()} />,
+    );
+    expect(screen.getByText(/Translatable Strings/)).toBeInTheDocument();
+  });
+
+  it('calls onOpenBlock when clicking a string row', () => {
+    const onOpenBlock = vi.fn();
+    const data = makeSampleTranslationData();
+    render(
+      <TranslationDashboard translationData={data} blocks={makeSampleBlocks()} onOpenBlock={onOpenBlock} />,
+    );
+    const row = screen.getByTestId('string-row-0');
+    fireEvent.click(row);
+    expect(onOpenBlock).toHaveBeenCalledWith('b1', 1);
+  });
+
+  it('filters by status pill', () => {
+    const data = makeSampleTranslationData();
+    render(
+      <TranslationDashboard translationData={data} blocks={makeSampleBlocks()} onOpenBlock={vi.fn()} />,
+    );
+    // Click "untranslated" status pill — there are two sets (file breakdown + shared),
+    // just click the first occurrence
+    const untranslatedButtons = screen.getAllByText('untranslated');
+    fireEvent.click(untranslatedButtons[0]);
+    // After filtering, the string count should reflect untranslated only
+    expect(screen.getByText(/Translatable Strings \(1\)/)).toBeInTheDocument();
+  });
+});

--- a/test/mocks/electronAPI.ts
+++ b/test/mocks/electronAPI.ts
@@ -84,6 +84,7 @@ export interface MockElectronAPI {
   runGame: Mock<(renpyPath: string, projectPath: string) => void>;
   stopGame: Mock<() => void>;
   checkRenpyPath: Mock<(path: string) => Promise<boolean>>;
+  generateTranslations: Mock<(sdkDir: string, projectPath: string, language: string) => Promise<{ success: boolean; output: string }>>;
   onGameStarted: Mock<(callback: (...args: unknown[]) => unknown) => Unsubscribe>;
   onGameStopped: Mock<(callback: (...args: unknown[]) => unknown) => Unsubscribe>;
   onGameError: Mock<(callback: (...args: unknown[]) => unknown) => Unsubscribe>;
@@ -151,6 +152,7 @@ export function createMockElectronAPI(): MockElectronAPI {
     runGame: vi.fn(),
     stopGame: vi.fn(),
     checkRenpyPath: vi.fn().mockResolvedValue(false),
+    generateTranslations: vi.fn().mockResolvedValue({ success: true, output: '' }),
     onGameStarted: vi.fn().mockReturnValue(noopUnsubscribe),
     onGameStopped: vi.fn().mockReturnValue(noopUnsubscribe),
     onGameError: vi.fn().mockReturnValue(noopUnsubscribe),

--- a/test/mocks/electronAPI.ts
+++ b/test/mocks/electronAPI.ts
@@ -84,7 +84,7 @@ export interface MockElectronAPI {
   runGame: Mock<(renpyPath: string, projectPath: string) => void>;
   stopGame: Mock<() => void>;
   checkRenpyPath: Mock<(path: string) => Promise<boolean>>;
-  generateTranslations: Mock<(sdkDir: string, projectPath: string, language: string) => Promise<{ success: boolean; output: string }>>;
+  generateTranslations: Mock<(sdkDir: string, projectPath: string, language: string) => Promise<{ success: boolean; output: string; error?: string }>>;
   onGameStarted: Mock<(callback: (...args: unknown[]) => unknown) => Unsubscribe>;
   onGameStopped: Mock<(callback: (...args: unknown[]) => unknown) => Unsubscribe>;
   onGameError: Mock<(callback: (...args: unknown[]) => unknown) => Unsubscribe>;

--- a/test/mocks/sampleData.ts
+++ b/test/mocks/sampleData.ts
@@ -152,6 +152,13 @@ export function createEmptyAnalysisResult(overrides: Partial<RenpyAnalysisResult
     routeLinks: [],
     identifiedRoutes: [],
     routesTruncated: false,
+    translationData: {
+      translatableStrings: [],
+      translatedStrings: new Map(),
+      languageCoverages: [],
+      detectedLanguages: [],
+      stringTranslations: new Map(),
+    },
     ...overrides,
   };
 }

--- a/test/renpyTranslationParser.test.ts
+++ b/test/renpyTranslationParser.test.ts
@@ -4,6 +4,8 @@ import {
   extractLanguageFromPath,
   extractTranslatableStrings,
   extractTranslatedStrings,
+  deriveSourceFilePath,
+  buildStringTranslationMap,
   computeLanguageCoverages,
   performTranslationAnalysis,
 } from '../lib/renpyTranslationParser';
@@ -49,6 +51,25 @@ describe('extractLanguageFromPath', () => {
 
   it('returns null for non-translation paths', () => {
     expect(extractLanguageFromPath('game/script.rpy')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveSourceFilePath
+// ---------------------------------------------------------------------------
+
+describe('deriveSourceFilePath', () => {
+  it('strips the tl/<lang>/ segment', () => {
+    expect(deriveSourceFilePath('game/tl/french/script.rpy', 'french')).toBe('game/script.rpy');
+    expect(deriveSourceFilePath('game/tl/japanese/chapter1.rpy', 'japanese')).toBe('game/chapter1.rpy');
+  });
+
+  it('handles backslash paths', () => {
+    expect(deriveSourceFilePath('game\\tl\\french\\script.rpy', 'french')).toBe('game/script.rpy');
+  });
+
+  it('returns the original path if tl segment not found', () => {
+    expect(deriveSourceFilePath('game/script.rpy', 'french')).toBe('game/script.rpy');
   });
 });
 
@@ -155,6 +176,7 @@ describe('extractTranslatedStrings', () => {
     expect(translatedStrings.get('french')).toHaveLength(1);
     expect(translatedStrings.get('french')![0].translatedText).toBe('Bonjour le monde');
     expect(translatedStrings.get('french')![0].id).toBe('start_abc123');
+    expect(translatedStrings.get('french')![0].characterTag).toBe('e');
   });
 
   it('parses translate <lang> <id>: blocks with narration', () => {
@@ -166,6 +188,7 @@ describe('extractTranslatedStrings', () => {
     const { translatedStrings } = extractTranslatedStrings([block]);
     expect(translatedStrings.get('spanish')).toHaveLength(1);
     expect(translatedStrings.get('spanish')![0].translatedText).toBe('Habia una vez...');
+    expect(translatedStrings.get('spanish')![0].characterTag).toBeNull();
   });
 
   it('parses translate <lang> strings: old/new tables', () => {
@@ -177,7 +200,9 @@ describe('extractTranslatedStrings', () => {
     const { translatedStrings } = extractTranslatedStrings([block]);
     expect(translatedStrings.get('german')).toHaveLength(2);
     expect(translatedStrings.get('german')![0].translatedText).toBe('Anfang');
+    expect(translatedStrings.get('german')![0].sourceText).toBe('Start');
     expect(translatedStrings.get('german')![1].translatedText).toBe('Beenden');
+    expect(translatedStrings.get('german')![1].sourceText).toBe('Quit');
   });
 
   it('skips non-translation files', () => {
@@ -203,18 +228,94 @@ describe('extractTranslatedStrings', () => {
 });
 
 // ---------------------------------------------------------------------------
+// buildStringTranslationMap
+// ---------------------------------------------------------------------------
+
+describe('buildStringTranslationMap', () => {
+  it('matches translated dialogue to source by file path and character tag', () => {
+    const source = [
+      { id: 'b1:2', sourceText: 'Hello', blockId: 'b1', filePath: 'game/script.rpy', line: 2, labelScope: 'start', characterTag: 'e', type: 'dialogue' as const },
+    ];
+    const translated = new Map([
+      ['french', [{ id: 'start_abc', translatedText: 'Bonjour', blockId: 'tl1', filePath: 'game/tl/french/script.rpy', line: 2, language: 'french', characterTag: 'e', sourceText: null }]],
+    ]);
+    const map = buildStringTranslationMap(source, translated, new Set(['french']));
+    expect(map.has('b1:2')).toBe(true);
+    expect(map.get('b1:2')!.get('french')!.translatedText).toBe('Bonjour');
+  });
+
+  it('matches stale translations (text identical to source)', () => {
+    const source = [
+      { id: 'b1:2', sourceText: 'Hello', blockId: 'b1', filePath: 'game/script.rpy', line: 2, labelScope: 'start', characterTag: 'e', type: 'dialogue' as const },
+    ];
+    const translated = new Map([
+      ['french', [{ id: 'start_abc', translatedText: 'Hello', blockId: 'tl1', filePath: 'game/tl/french/script.rpy', line: 2, language: 'french', characterTag: 'e', sourceText: null }]],
+    ]);
+    const map = buildStringTranslationMap(source, translated, new Set(['french']));
+    expect(map.has('b1:2')).toBe(true);
+    expect(map.get('b1:2')!.get('french')!.translatedText).toBe('Hello');
+  });
+
+  it('matches string table entries by source text', () => {
+    const source = [
+      { id: 'b1:3', sourceText: 'Start Game', blockId: 'b1', filePath: 'game/screens.rpy', line: 3, labelScope: null, characterTag: null, type: 'menu-choice' as const },
+    ];
+    const translated = new Map([
+      ['french', [{ id: 'strings:Start Game', translatedText: 'Commencer', blockId: 'tl1', filePath: 'game/tl/french/screens.rpy', line: 3, language: 'french', characterTag: null, sourceText: 'Start Game' }]],
+    ]);
+    const map = buildStringTranslationMap(source, translated, new Set(['french']));
+    expect(map.has('b1:3')).toBe(true);
+    expect(map.get('b1:3')!.get('french')!.translatedText).toBe('Commencer');
+  });
+
+  it('matches narration translations', () => {
+    const source = [
+      { id: 'b1:2', sourceText: 'Once upon a time', blockId: 'b1', filePath: 'game/script.rpy', line: 2, labelScope: 'start', characterTag: null, type: 'narration' as const },
+    ];
+    const translated = new Map([
+      ['french', [{ id: 'start_xyz', translatedText: 'Il etait une fois', blockId: 'tl1', filePath: 'game/tl/french/script.rpy', line: 2, language: 'french', characterTag: null, sourceText: null }]],
+    ]);
+    const map = buildStringTranslationMap(source, translated, new Set(['french']));
+    expect(map.has('b1:2')).toBe(true);
+    expect(map.get('b1:2')!.get('french')!.translatedText).toBe('Il etait une fois');
+  });
+
+  it('handles multiple languages for the same source string', () => {
+    const source = [
+      { id: 'b1:2', sourceText: 'Hello', blockId: 'b1', filePath: 'game/script.rpy', line: 2, labelScope: 'start', characterTag: 'e', type: 'dialogue' as const },
+    ];
+    const translated = new Map([
+      ['french', [{ id: 'start_abc', translatedText: 'Bonjour', blockId: 'tl1', filePath: 'game/tl/french/script.rpy', line: 2, language: 'french', characterTag: 'e', sourceText: null }]],
+      ['german', [{ id: 'start_abc', translatedText: 'Hallo', blockId: 'tl2', filePath: 'game/tl/german/script.rpy', line: 2, language: 'german', characterTag: 'e', sourceText: null }]],
+    ]);
+    const map = buildStringTranslationMap(source, translated, new Set(['french', 'german']));
+    expect(map.get('b1:2')!.size).toBe(2);
+    expect(map.get('b1:2')!.get('french')!.translatedText).toBe('Bonjour');
+    expect(map.get('b1:2')!.get('german')!.translatedText).toBe('Hallo');
+  });
+
+  it('returns empty map when no translations', () => {
+    const source = [
+      { id: 'b1:2', sourceText: 'Hello', blockId: 'b1', filePath: 'game/script.rpy', line: 2, labelScope: 'start', characterTag: 'e', type: 'dialogue' as const },
+    ];
+    const map = buildStringTranslationMap(source, new Map(), new Set(['french']));
+    expect(map.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // computeLanguageCoverages
 // ---------------------------------------------------------------------------
 
 describe('computeLanguageCoverages', () => {
   it('computes 100% coverage', () => {
     const source = [
-      { id: 'id1', sourceText: 'Hello', blockId: 'b1', filePath: 'game/script.rpy', line: 1, labelScope: null, characterTag: 'e', type: 'dialogue' as const },
+      { id: 'b1:1', sourceText: 'Hello', blockId: 'b1', filePath: 'game/script.rpy', line: 1, labelScope: null, characterTag: 'e', type: 'dialogue' as const },
     ];
-    const translated = new Map([
-      ['french', [{ id: 'id1', translatedText: 'Bonjour', blockId: 'tl1', filePath: 'game/tl/french/script.rpy', line: 2, language: 'french' }]],
+    const stringTranslations = new Map([
+      ['b1:1', new Map([['french', { id: 'start_abc', translatedText: 'Bonjour', blockId: 'tl1', filePath: 'game/tl/french/script.rpy', line: 2, language: 'french', characterTag: 'e', sourceText: null }]])],
     ]);
-    const coverages = computeLanguageCoverages(source, translated, new Set(['french']));
+    const coverages = computeLanguageCoverages(source, stringTranslations, new Set(['french']));
     expect(coverages).toHaveLength(1);
     expect(coverages[0].completionPercent).toBe(100);
     expect(coverages[0].untranslatedCount).toBe(0);
@@ -222,7 +323,7 @@ describe('computeLanguageCoverages', () => {
 
   it('computes 0% when no translations exist', () => {
     const source = [
-      { id: 'id1', sourceText: 'Hello', blockId: 'b1', filePath: 'game/script.rpy', line: 1, labelScope: null, characterTag: 'e', type: 'dialogue' as const },
+      { id: 'b1:1', sourceText: 'Hello', blockId: 'b1', filePath: 'game/script.rpy', line: 1, labelScope: null, characterTag: 'e', type: 'dialogue' as const },
     ];
     const coverages = computeLanguageCoverages(source, new Map(), new Set(['french']));
     expect(coverages).toHaveLength(1);
@@ -232,13 +333,13 @@ describe('computeLanguageCoverages', () => {
 
   it('computes partial coverage', () => {
     const source = [
-      { id: 'id1', sourceText: 'Hello', blockId: 'b1', filePath: 'game/script.rpy', line: 1, labelScope: null, characterTag: 'e', type: 'dialogue' as const },
-      { id: 'id2', sourceText: 'Goodbye', blockId: 'b1', filePath: 'game/script.rpy', line: 2, labelScope: null, characterTag: 'e', type: 'dialogue' as const },
+      { id: 'b1:1', sourceText: 'Hello', blockId: 'b1', filePath: 'game/script.rpy', line: 1, labelScope: null, characterTag: 'e', type: 'dialogue' as const },
+      { id: 'b1:2', sourceText: 'Goodbye', blockId: 'b1', filePath: 'game/script.rpy', line: 2, labelScope: null, characterTag: 'e', type: 'dialogue' as const },
     ];
-    const translated = new Map([
-      ['french', [{ id: 'id1', translatedText: 'Bonjour', blockId: 'tl1', filePath: 'game/tl/french/script.rpy', line: 2, language: 'french' }]],
+    const stringTranslations = new Map([
+      ['b1:1', new Map([['french', { id: 'start_abc', translatedText: 'Bonjour', blockId: 'tl1', filePath: 'game/tl/french/script.rpy', line: 2, language: 'french', characterTag: 'e', sourceText: null }]])],
     ]);
-    const coverages = computeLanguageCoverages(source, translated, new Set(['french']));
+    const coverages = computeLanguageCoverages(source, stringTranslations, new Set(['french']));
     expect(coverages[0].completionPercent).toBe(50);
     expect(coverages[0].translatedCount).toBe(1);
     expect(coverages[0].untranslatedCount).toBe(1);
@@ -251,25 +352,30 @@ describe('computeLanguageCoverages', () => {
 
   it('detects stale translations (text matches source)', () => {
     const source = [
-      { id: 'id1', sourceText: 'Hello', blockId: 'b1', filePath: 'game/script.rpy', line: 1, labelScope: null, characterTag: 'e', type: 'dialogue' as const },
+      { id: 'b1:1', sourceText: 'Hello', blockId: 'b1', filePath: 'game/script.rpy', line: 1, labelScope: null, characterTag: 'e', type: 'dialogue' as const },
     ];
-    const translated = new Map([
-      ['french', [{ id: 'id1', translatedText: 'Hello', blockId: 'tl1', filePath: 'game/tl/french/script.rpy', line: 2, language: 'french' }]],
+    const stringTranslations = new Map([
+      ['b1:1', new Map([['french', { id: 'start_abc', translatedText: 'Hello', blockId: 'tl1', filePath: 'game/tl/french/script.rpy', line: 2, language: 'french', characterTag: 'e', sourceText: null }]])],
     ]);
-    const coverages = computeLanguageCoverages(source, translated, new Set(['french']));
+    const coverages = computeLanguageCoverages(source, stringTranslations, new Set(['french']));
     expect(coverages[0].staleCount).toBe(1);
+    expect(coverages[0].completionPercent).toBe(0);
   });
 
   it('includes file breakdown', () => {
     const source = [
-      { id: 'id1', sourceText: 'Hello', blockId: 'b1', filePath: 'game/script.rpy', line: 1, labelScope: null, characterTag: 'e', type: 'dialogue' as const },
-      { id: 'id2', sourceText: 'Bye', blockId: 'b2', filePath: 'game/chapter2.rpy', line: 1, labelScope: null, characterTag: 'e', type: 'dialogue' as const },
+      { id: 'b1:1', sourceText: 'Hello', blockId: 'b1', filePath: 'game/script.rpy', line: 1, labelScope: null, characterTag: 'e', type: 'dialogue' as const },
+      { id: 'b2:1', sourceText: 'Bye', blockId: 'b2', filePath: 'game/chapter2.rpy', line: 1, labelScope: null, characterTag: 'e', type: 'dialogue' as const },
     ];
-    const translated = new Map([
-      ['french', [{ id: 'id1', translatedText: 'Bonjour', blockId: 'tl1', filePath: 'game/tl/french/script.rpy', line: 2, language: 'french' }]],
+    const stringTranslations = new Map([
+      ['b1:1', new Map([['french', { id: 'start_abc', translatedText: 'Bonjour', blockId: 'tl1', filePath: 'game/tl/french/script.rpy', line: 2, language: 'french', characterTag: 'e', sourceText: null }]])],
     ]);
-    const coverages = computeLanguageCoverages(source, translated, new Set(['french']));
+    const coverages = computeLanguageCoverages(source, stringTranslations, new Set(['french']));
     expect(coverages[0].fileBreakdown).toHaveLength(2);
+    const scriptFile = coverages[0].fileBreakdown.find(f => f.sourceFilePath === 'game/script.rpy');
+    expect(scriptFile!.translatedCount).toBe(1);
+    const ch2File = coverages[0].fileBreakdown.find(f => f.sourceFilePath === 'game/chapter2.rpy');
+    expect(ch2File!.translatedCount).toBe(0);
   });
 });
 
@@ -298,6 +404,8 @@ describe('performTranslationAnalysis', () => {
     expect(result.detectedLanguages).toEqual(['french']);
     expect(result.languageCoverages).toHaveLength(1);
     expect(result.languageCoverages[0].language).toBe('french');
+    expect(result.languageCoverages[0].translatedCount).toBe(2);
+    expect(result.languageCoverages[0].completionPercent).toBe(100);
   });
 
   it('returns empty data when there are no translatable strings', () => {
@@ -339,7 +447,7 @@ describe('performTranslationAnalysis', () => {
     expect(result.languageCoverages[0].completionPercent).toBe(0);
   });
 
-  it('builds stringTranslations lookup', () => {
+  it('builds stringTranslations lookup keyed by source string IDs', () => {
     const blocks: AnalysisBlock[] = [
       makeBlock({
         id: 'src',
@@ -358,7 +466,47 @@ describe('performTranslationAnalysis', () => {
       }),
     ];
     const result = performTranslationAnalysis(blocks, new Map(), { start: { blockId: 'src' } });
-    expect(result.stringTranslations.has('myid')).toBe(true);
-    expect(result.stringTranslations.get('myid')!.size).toBe(2);
+    // The key should be the SOURCE string ID (src:2), not the Ren'Py translation ID (myid)
+    expect(result.stringTranslations.has('src:2')).toBe(true);
+    expect(result.stringTranslations.get('src:2')!.size).toBe(2);
+    expect(result.stringTranslations.get('src:2')!.get('french')!.translatedText).toBe('Bonjour');
+    expect(result.stringTranslations.get('src:2')!.get('german')!.translatedText).toBe('Hallo');
+  });
+
+  it('correctly identifies stale translations in end-to-end analysis', () => {
+    const blocks: AnalysisBlock[] = [
+      makeBlock({
+        id: 'src',
+        filePath: 'game/script.rpy',
+        content: 'label start:\n    e "Hello"\n',
+      }),
+      makeBlock({
+        id: 'tl-fr',
+        filePath: 'game/tl/french/script.rpy',
+        content: 'translate french start_abc:\n    e "Hello"\n',
+      }),
+    ];
+    const result = performTranslationAnalysis(blocks, new Map(), { start: { blockId: 'src' } });
+    expect(result.languageCoverages[0].staleCount).toBe(1);
+    expect(result.languageCoverages[0].translatedCount).toBe(1);
+    expect(result.languageCoverages[0].completionPercent).toBe(0);
+  });
+
+  it('matches string table entries to menu choices', () => {
+    const blocks: AnalysisBlock[] = [
+      makeBlock({
+        id: 'src',
+        filePath: 'game/script.rpy',
+        content: 'label start:\n    menu:\n        "Go left":\n            jump left\n',
+      }),
+      makeBlock({
+        id: 'tl-fr',
+        filePath: 'game/tl/french/script.rpy',
+        content: 'translate french strings:\n    old "Go left"\n    new "Aller a gauche"\n',
+      }),
+    ];
+    const result = performTranslationAnalysis(blocks, new Map(), { start: { blockId: 'src' } });
+    expect(result.languageCoverages[0].translatedCount).toBe(1);
+    expect(result.languageCoverages[0].completionPercent).toBe(100);
   });
 });

--- a/test/renpyTranslationParser.test.ts
+++ b/test/renpyTranslationParser.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isTranslationFile,
+  extractLanguageFromPath,
+  extractTranslatableStrings,
+  extractTranslatedStrings,
+  computeLanguageCoverages,
+  performTranslationAnalysis,
+} from '../lib/renpyTranslationParser';
+import type { AnalysisBlock } from '../lib/renpyTranslationParser';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeBlock(overrides: Partial<AnalysisBlock> & { content: string }): AnalysisBlock {
+  return {
+    id: overrides.id ?? 'block-1',
+    filePath: overrides.filePath ?? 'game/script.rpy',
+    content: overrides.content,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// isTranslationFile / extractLanguageFromPath
+// ---------------------------------------------------------------------------
+
+describe('isTranslationFile', () => {
+  it('returns true for paths under /tl/<lang>/', () => {
+    expect(isTranslationFile('game/tl/french/script.rpy')).toBe(true);
+    expect(isTranslationFile('game/tl/japanese/common.rpy')).toBe(true);
+  });
+
+  it('returns false for source paths', () => {
+    expect(isTranslationFile('game/script.rpy')).toBe(false);
+    expect(isTranslationFile('game/screens.rpy')).toBe(false);
+  });
+
+  it('handles backslash paths (Windows)', () => {
+    expect(isTranslationFile('game\\tl\\french\\script.rpy')).toBe(true);
+  });
+});
+
+describe('extractLanguageFromPath', () => {
+  it('extracts the language code', () => {
+    expect(extractLanguageFromPath('game/tl/french/script.rpy')).toBe('french');
+    expect(extractLanguageFromPath('game/tl/ja_JP/common.rpy')).toBe('ja_JP');
+  });
+
+  it('returns null for non-translation paths', () => {
+    expect(extractLanguageFromPath('game/script.rpy')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractTranslatableStrings
+// ---------------------------------------------------------------------------
+
+describe('extractTranslatableStrings', () => {
+  it('extracts dialogue lines', () => {
+    const block = makeBlock({
+      content: 'label start:\n    e "Hello world"\n    return\n',
+    });
+    const result = extractTranslatableStrings([block], new Map(), {
+      start: { blockId: 'block-1' },
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].sourceText).toBe('Hello world');
+    expect(result[0].type).toBe('dialogue');
+    expect(result[0].characterTag).toBe('e');
+    expect(result[0].labelScope).toBe('start');
+  });
+
+  it('extracts narration lines', () => {
+    const block = makeBlock({
+      content: 'label intro:\n    "Once upon a time..."\n',
+    });
+    const result = extractTranslatableStrings([block], new Map(), {
+      intro: { blockId: 'block-1' },
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].sourceText).toBe('Once upon a time...');
+    expect(result[0].type).toBe('narration');
+    expect(result[0].characterTag).toBeNull();
+  });
+
+  it('extracts menu choices', () => {
+    const block = makeBlock({
+      content: 'label choice:\n    menu:\n        "Go left":\n            jump left\n        "Go right":\n            jump right\n',
+    });
+    const result = extractTranslatableStrings([block], new Map(), {
+      choice: { blockId: 'block-1' },
+    });
+    expect(result).toHaveLength(2);
+    expect(result[0].sourceText).toBe('Go left');
+    expect(result[0].type).toBe('menu-choice');
+    expect(result[1].sourceText).toBe('Go right');
+  });
+
+  it('skips translation files', () => {
+    const block = makeBlock({
+      filePath: 'game/tl/french/script.rpy',
+      content: 'label start:\n    e "Bonjour"\n',
+    });
+    const result = extractTranslatableStrings([block], new Map(), {});
+    expect(result).toHaveLength(0);
+  });
+
+  it('skips Ren\'Py keyword lines that look like dialogue', () => {
+    const block = makeBlock({
+      content: 'label start:\n    show eileen happy\n    scene bg room\n    e "Real dialogue"\n',
+    });
+    const result = extractTranslatableStrings([block], new Map(), {
+      start: { blockId: 'block-1' },
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].sourceText).toBe('Real dialogue');
+  });
+
+  it('returns empty for blocks with no translatable content', () => {
+    const block = makeBlock({
+      content: 'init python:\n    config.screen_width = 1920\n',
+    });
+    const result = extractTranslatableStrings([block], new Map(), {});
+    expect(result).toHaveLength(0);
+  });
+
+  it('handles multiple labels in one block', () => {
+    const block = makeBlock({
+      content: 'label part1:\n    e "Line A"\nlabel part2:\n    e "Line B"\n',
+    });
+    const result = extractTranslatableStrings([block], new Map(), {
+      part1: { blockId: 'block-1' },
+      part2: { blockId: 'block-1' },
+    });
+    expect(result).toHaveLength(2);
+    expect(result[0].labelScope).toBe('part1');
+    expect(result[1].labelScope).toBe('part2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractTranslatedStrings
+// ---------------------------------------------------------------------------
+
+describe('extractTranslatedStrings', () => {
+  it('parses translate <lang> <id>: blocks with dialogue', () => {
+    const block = makeBlock({
+      id: 'tl-block',
+      filePath: 'game/tl/french/script.rpy',
+      content: 'translate french start_abc123:\n    e "Bonjour le monde"\n',
+    });
+    const { translatedStrings, detectedLanguages } = extractTranslatedStrings([block]);
+    expect(detectedLanguages.has('french')).toBe(true);
+    expect(translatedStrings.get('french')).toHaveLength(1);
+    expect(translatedStrings.get('french')![0].translatedText).toBe('Bonjour le monde');
+    expect(translatedStrings.get('french')![0].id).toBe('start_abc123');
+  });
+
+  it('parses translate <lang> <id>: blocks with narration', () => {
+    const block = makeBlock({
+      id: 'tl-block',
+      filePath: 'game/tl/spanish/script.rpy',
+      content: 'translate spanish intro_xyz:\n    "Habia una vez..."\n',
+    });
+    const { translatedStrings } = extractTranslatedStrings([block]);
+    expect(translatedStrings.get('spanish')).toHaveLength(1);
+    expect(translatedStrings.get('spanish')![0].translatedText).toBe('Habia una vez...');
+  });
+
+  it('parses translate <lang> strings: old/new tables', () => {
+    const block = makeBlock({
+      id: 'tl-block',
+      filePath: 'game/tl/german/common.rpy',
+      content: 'translate german strings:\n    old "Start"\n    new "Anfang"\n    old "Quit"\n    new "Beenden"\n',
+    });
+    const { translatedStrings } = extractTranslatedStrings([block]);
+    expect(translatedStrings.get('german')).toHaveLength(2);
+    expect(translatedStrings.get('german')![0].translatedText).toBe('Anfang');
+    expect(translatedStrings.get('german')![1].translatedText).toBe('Beenden');
+  });
+
+  it('skips non-translation files', () => {
+    const block = makeBlock({
+      filePath: 'game/script.rpy',
+      content: 'label start:\n    e "Hello"\n',
+    });
+    const { translatedStrings, detectedLanguages } = extractTranslatedStrings([block]);
+    expect(translatedStrings.size).toBe(0);
+    expect(detectedLanguages.size).toBe(0);
+  });
+
+  it('detects multiple languages', () => {
+    const blocks = [
+      makeBlock({ id: 'fr', filePath: 'game/tl/french/script.rpy', content: 'translate french id1:\n    e "Bonjour"\n' }),
+      makeBlock({ id: 'de', filePath: 'game/tl/german/script.rpy', content: 'translate german id1:\n    e "Hallo"\n' }),
+    ];
+    const { detectedLanguages } = extractTranslatedStrings(blocks);
+    expect(detectedLanguages.size).toBe(2);
+    expect(detectedLanguages.has('french')).toBe(true);
+    expect(detectedLanguages.has('german')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeLanguageCoverages
+// ---------------------------------------------------------------------------
+
+describe('computeLanguageCoverages', () => {
+  it('computes 100% coverage', () => {
+    const source = [
+      { id: 'id1', sourceText: 'Hello', blockId: 'b1', filePath: 'game/script.rpy', line: 1, labelScope: null, characterTag: 'e', type: 'dialogue' as const },
+    ];
+    const translated = new Map([
+      ['french', [{ id: 'id1', translatedText: 'Bonjour', blockId: 'tl1', filePath: 'game/tl/french/script.rpy', line: 2, language: 'french' }]],
+    ]);
+    const coverages = computeLanguageCoverages(source, translated, new Set(['french']));
+    expect(coverages).toHaveLength(1);
+    expect(coverages[0].completionPercent).toBe(100);
+    expect(coverages[0].untranslatedCount).toBe(0);
+  });
+
+  it('computes 0% when no translations exist', () => {
+    const source = [
+      { id: 'id1', sourceText: 'Hello', blockId: 'b1', filePath: 'game/script.rpy', line: 1, labelScope: null, characterTag: 'e', type: 'dialogue' as const },
+    ];
+    const coverages = computeLanguageCoverages(source, new Map(), new Set(['french']));
+    expect(coverages).toHaveLength(1);
+    expect(coverages[0].completionPercent).toBe(0);
+    expect(coverages[0].untranslatedCount).toBe(1);
+  });
+
+  it('computes partial coverage', () => {
+    const source = [
+      { id: 'id1', sourceText: 'Hello', blockId: 'b1', filePath: 'game/script.rpy', line: 1, labelScope: null, characterTag: 'e', type: 'dialogue' as const },
+      { id: 'id2', sourceText: 'Goodbye', blockId: 'b1', filePath: 'game/script.rpy', line: 2, labelScope: null, characterTag: 'e', type: 'dialogue' as const },
+    ];
+    const translated = new Map([
+      ['french', [{ id: 'id1', translatedText: 'Bonjour', blockId: 'tl1', filePath: 'game/tl/french/script.rpy', line: 2, language: 'french' }]],
+    ]);
+    const coverages = computeLanguageCoverages(source, translated, new Set(['french']));
+    expect(coverages[0].completionPercent).toBe(50);
+    expect(coverages[0].translatedCount).toBe(1);
+    expect(coverages[0].untranslatedCount).toBe(1);
+  });
+
+  it('returns empty array when no languages detected', () => {
+    const coverages = computeLanguageCoverages([], new Map(), new Set());
+    expect(coverages).toHaveLength(0);
+  });
+
+  it('detects stale translations (text matches source)', () => {
+    const source = [
+      { id: 'id1', sourceText: 'Hello', blockId: 'b1', filePath: 'game/script.rpy', line: 1, labelScope: null, characterTag: 'e', type: 'dialogue' as const },
+    ];
+    const translated = new Map([
+      ['french', [{ id: 'id1', translatedText: 'Hello', blockId: 'tl1', filePath: 'game/tl/french/script.rpy', line: 2, language: 'french' }]],
+    ]);
+    const coverages = computeLanguageCoverages(source, translated, new Set(['french']));
+    expect(coverages[0].staleCount).toBe(1);
+  });
+
+  it('includes file breakdown', () => {
+    const source = [
+      { id: 'id1', sourceText: 'Hello', blockId: 'b1', filePath: 'game/script.rpy', line: 1, labelScope: null, characterTag: 'e', type: 'dialogue' as const },
+      { id: 'id2', sourceText: 'Bye', blockId: 'b2', filePath: 'game/chapter2.rpy', line: 1, labelScope: null, characterTag: 'e', type: 'dialogue' as const },
+    ];
+    const translated = new Map([
+      ['french', [{ id: 'id1', translatedText: 'Bonjour', blockId: 'tl1', filePath: 'game/tl/french/script.rpy', line: 2, language: 'french' }]],
+    ]);
+    const coverages = computeLanguageCoverages(source, translated, new Set(['french']));
+    expect(coverages[0].fileBreakdown).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// performTranslationAnalysis (integration)
+// ---------------------------------------------------------------------------
+
+describe('performTranslationAnalysis', () => {
+  it('runs end-to-end with source + translation blocks', () => {
+    const blocks: AnalysisBlock[] = [
+      makeBlock({
+        id: 'src',
+        filePath: 'game/script.rpy',
+        content: 'label start:\n    e "Hello world"\n    "Narration here"\n',
+      }),
+      makeBlock({
+        id: 'tl-fr',
+        filePath: 'game/tl/french/script.rpy',
+        content: 'translate french start_abc:\n    e "Bonjour le monde"\n\ntranslate french start_def:\n    "Narration ici"\n',
+      }),
+    ];
+    const labels = { start: { blockId: 'src' } };
+    const result = performTranslationAnalysis(blocks, new Map(), labels);
+
+    expect(result.translatableStrings).toHaveLength(2);
+    expect(result.detectedLanguages).toEqual(['french']);
+    expect(result.languageCoverages).toHaveLength(1);
+    expect(result.languageCoverages[0].language).toBe('french');
+  });
+
+  it('returns empty data when there are no translatable strings', () => {
+    const blocks: AnalysisBlock[] = [
+      makeBlock({
+        content: 'init python:\n    config.screen_width = 1920\n',
+      }),
+    ];
+    const result = performTranslationAnalysis(blocks, new Map(), {});
+    expect(result.translatableStrings).toHaveLength(0);
+    expect(result.detectedLanguages).toHaveLength(0);
+    expect(result.languageCoverages).toHaveLength(0);
+  });
+
+  it('handles source-only (no translation files)', () => {
+    const blocks: AnalysisBlock[] = [
+      makeBlock({
+        content: 'label start:\n    e "Hello"\n',
+      }),
+    ];
+    const result = performTranslationAnalysis(blocks, new Map(), { start: { blockId: 'block-1' } });
+    expect(result.translatableStrings).toHaveLength(1);
+    expect(result.detectedLanguages).toHaveLength(0);
+    expect(result.languageCoverages).toHaveLength(0);
+  });
+
+  it('handles translation-only (no source blocks)', () => {
+    const blocks: AnalysisBlock[] = [
+      makeBlock({
+        id: 'tl-fr',
+        filePath: 'game/tl/french/script.rpy',
+        content: 'translate french start_abc:\n    e "Bonjour"\n',
+      }),
+    ];
+    const result = performTranslationAnalysis(blocks, new Map(), {});
+    expect(result.translatableStrings).toHaveLength(0);
+    expect(result.detectedLanguages).toEqual(['french']);
+    expect(result.languageCoverages).toHaveLength(1);
+    expect(result.languageCoverages[0].completionPercent).toBe(0);
+  });
+
+  it('builds stringTranslations lookup', () => {
+    const blocks: AnalysisBlock[] = [
+      makeBlock({
+        id: 'src',
+        filePath: 'game/script.rpy',
+        content: 'label start:\n    e "Hello"\n',
+      }),
+      makeBlock({
+        id: 'tl-fr',
+        filePath: 'game/tl/french/script.rpy',
+        content: 'translate french myid:\n    e "Bonjour"\n',
+      }),
+      makeBlock({
+        id: 'tl-de',
+        filePath: 'game/tl/german/script.rpy',
+        content: 'translate german myid:\n    e "Hallo"\n',
+      }),
+    ];
+    const result = performTranslationAnalysis(blocks, new Map(), { start: { blockId: 'src' } });
+    expect(result.stringTranslations.has('myid')).toBe(true);
+    expect(result.stringTranslations.get('myid')!.size).toBe(2);
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -553,6 +553,10 @@ export interface TranslatedString {
   filePath: string;
   line: number;
   language: string;
+  /** Character tag from dialogue translation, null for narration/string-table entries. */
+  characterTag: string | null;
+  /** Source text from old/new string tables, null for block translations. */
+  sourceText: string | null;
 }
 
 /** Per-language translation coverage statistics. */

--- a/types.ts
+++ b/types.ts
@@ -1131,6 +1131,7 @@ declare global {
           runGame: (renpyPath: string, projectPath: string) => void;
           stopGame: () => void;
           checkRenpyPath: (path: string) => Promise<boolean>;
+          generateTranslations: (sdkDir: string, projectPath: string, language: string) => Promise<{ success: boolean; output: string }>;
           onGameStarted: (callback: () => void) => () => void;
           onGameStopped: (callback: () => void) => () => void;
           onGameError: (callback: (error: string) => void) => () => void;

--- a/types.ts
+++ b/types.ts
@@ -1131,7 +1131,7 @@ declare global {
           runGame: (renpyPath: string, projectPath: string) => void;
           stopGame: () => void;
           checkRenpyPath: (path: string) => Promise<boolean>;
-          generateTranslations: (sdkDir: string, projectPath: string, language: string) => Promise<{ success: boolean; output: string }>;
+          generateTranslations: (sdkDir: string, projectPath: string, language: string) => Promise<{ success: boolean; output: string; error?: string }>;
           onGameStarted: (callback: () => void) => () => void;
           onGameStopped: (callback: () => void) => () => void;
           onGameError: (callback: (error: string) => void) => () => void;

--- a/types.ts
+++ b/types.ts
@@ -530,7 +530,60 @@ export interface IdentifiedRoute {
  * @property {RouteLink[]} routeLinks - All connections in Flow Canvas
  * @property {IdentifiedRoute[]} identifiedRoutes - Identified narrative paths
  * @property {boolean} routesTruncated - True when route enumeration hit the hard cap
+ * @property {TranslationAnalysisResult} translationData - Translation coverage data
  */
+
+/** A source string that can be translated (dialogue, narration, or menu choice). */
+export interface TranslatableString {
+  id: string;
+  sourceText: string;
+  blockId: string;
+  filePath: string;
+  line: number;
+  labelScope: string | null;
+  characterTag: string | null;
+  type: 'dialogue' | 'narration' | 'menu-choice';
+}
+
+/** A translated string extracted from a `translate` block. */
+export interface TranslatedString {
+  id: string;
+  translatedText: string;
+  blockId: string;
+  filePath: string;
+  line: number;
+  language: string;
+}
+
+/** Per-language translation coverage statistics. */
+export interface LanguageCoverage {
+  language: string;
+  totalStrings: number;
+  translatedCount: number;
+  staleCount: number;
+  untranslatedCount: number;
+  completionPercent: number;
+  fileBreakdown: TranslationFileBreakdown[];
+}
+
+/** Per-file translation breakdown within a language. */
+export interface TranslationFileBreakdown {
+  sourceFilePath: string;
+  totalStrings: number;
+  translatedCount: number;
+  staleCount: number;
+  completionPercent: number;
+}
+
+/** Top-level translation analysis result. */
+export interface TranslationAnalysisResult {
+  translatableStrings: TranslatableString[];
+  translatedStrings: Map<string, TranslatedString[]>;
+  languageCoverages: LanguageCoverage[];
+  detectedLanguages: string[];
+  stringTranslations: Map<string, Map<string, TranslatedString>>;
+}
+
 export interface RenpyAnalysisResult {
   links: Link[];
   invalidJumps: { [blockId: string]: string[] };
@@ -555,6 +608,7 @@ export interface RenpyAnalysisResult {
   routeLinks: RouteLink[];
   identifiedRoutes: IdentifiedRoute[];
   routesTruncated: boolean;
+  translationData: TranslationAnalysisResult;
 }
 
 
@@ -574,7 +628,7 @@ export interface RenpyAnalysisResult {
  */
 export interface EditorTab {
   id: string;
-  type: 'canvas' | 'route-canvas' | 'choice-canvas' | 'punchlist' | 'diagnostics' | 'editor' | 'image' | 'audio' | 'character' | 'scene-composer' | 'imagemap-composer' | 'screen-layout-composer' | 'stats' | 'markdown';
+  type: 'canvas' | 'route-canvas' | 'choice-canvas' | 'punchlist' | 'diagnostics' | 'editor' | 'image' | 'audio' | 'character' | 'scene-composer' | 'imagemap-composer' | 'screen-layout-composer' | 'stats' | 'markdown' | 'translations';
   blockId?: string;
   filePath?: string;
   characterTag?: string;

--- a/workers/renpyAnalysis.worker.ts
+++ b/workers/renpyAnalysis.worker.ts
@@ -12,6 +12,7 @@ import { performRenpyAnalysis, performRouteAnalysis } from '../hooks/useRenpyAna
 import type { AnalysisBlock } from '../hooks/useRenpyAnalysis';
 import type { RenpyAnalysisResult } from '../types';
 import { formatErrorMessage } from '../lib/formatErrorMessage';
+import { performTranslationAnalysis } from '../lib/renpyTranslationParser';
 
 interface WorkerRequest {
   id: number;
@@ -74,6 +75,10 @@ self.onmessage = (e: MessageEvent<WorkerRequest>) => {
     result.routeLinks = routeData.routeLinks;
     result.identifiedRoutes = routeData.identifiedRoutes;
     result.routesTruncated = routeData.routesTruncated;
+
+    self.postMessage({ id, type: 'progress', phase: 'Analyzing translations', percent: 80 });
+    const translationData = performTranslationAnalysis(blocks, result.dialogueLines, result.labels);
+    result.translationData = translationData;
 
     self.postMessage({ id, type: 'progress', phase: 'Finalizing', percent: 95 });
 


### PR DESCRIPTION
Fixes Issue #126.\n\n- Move the generate-translation UI into a modal so it is no longer clipped by the language cards.\n- Correct file-breakdown counts to exclude stale translations from effective translated totals.\n- Update the translated file filter so partially translated files still show up.\n- Add regression coverage for the stale-heavy breakdown and translated filter behavior.