### PR TITLE
fix: Resolve AppImage SUID sandbox error on Linux (#146)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -75,7 +75,7 @@ jobs:
           PLATFORM="${{ matrix.platform }}"
           mkdir -p final-artifacts
           # We move files to a new folder with generic names (no version, no date)
-          for f in release/*.exe release/*.dmg release/*.AppImage release/*.zip; do
+          for f in release/*.exe release/*.dmg release/*.AppImage release/*.deb release/*.zip; do
             [ -f "$f" ] || continue
             ext="${f##*.}"
             mv "$f" "final-artifacts/renide-nightly-${PLATFORM}.${ext}"
@@ -155,11 +155,13 @@ jobs:
             | macOS (Apple Silicon) | `renide-nightly-macos-arm64.dmg` |
             | macOS (Intel) | `renide-nightly-macos-intel.dmg` |
             | Windows | `renide-nightly-win.exe` |
-            | Linux | `renide-nightly-linux.AppImage` |
+            | Linux (Universal) | `renide-nightly-linux.AppImage` |
+            | Linux (Debian/Ubuntu) | `renide-nightly-linux.deb` |
 
             **Checksums:** See `SHA256SUMS.txt` below.
           files: |
             artifacts/*.exe
             artifacts/*.dmg
             artifacts/*.AppImage
+            artifacts/*.deb
             artifacts/SHA256SUMS.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,7 @@ jobs:
             release/*.exe
             release/*.dmg
             release/*.AppImage
+            release/*.deb
 
   publish:
     name: Publish Release
@@ -144,11 +145,13 @@ jobs:
             | macOS (Apple Silicon) | `renide-*.dmg` (from `macos-arm64`) |
             | macOS (Intel) | `renide-*.dmg` (from `macos-intel`) |
             | Windows | `renide-Setup-*.exe` |
-            | Linux | `renide-*.AppImage` |
+            | Linux (Universal) | `renide-*.AppImage` |
+            | Linux (Debian/Ubuntu) | `renide_*_amd64.deb` |
 
             **Checksums:** See `SHA256SUMS.txt` below.
           files: |
             artifacts/*.exe
             artifacts/*.dmg
             artifacts/*.AppImage
+            artifacts/*.deb
             artifacts/SHA256SUMS.txt

--- a/README.md
+++ b/README.md
@@ -210,13 +210,133 @@ Word counts, estimated play time, lines of dialogue, per-character dialogue brea
 
 ### Install (Recommended)
 
-1. Go to the **[releases page](https://github.com/bluemoonfoundry/vangard-renpy-ide/releases/latest)**
-2. Download the zip for your OS and unzip it
-3. **Windows**: run the `.exe` installer
-4. **macOS**: open the `.dmg` and move the app to your Applications folder
-5. **Linux**: make the `.AppImage` executable and run it
+Go to the **[releases page](https://github.com/bluemoonfoundry/vangard-renpy-ide/releases/latest)** and download the appropriate package for your operating system.
 
-On first launch, open an existing Ren'Py project folder or create a new project with the wizard.
+#### Windows
+
+**Download:** `renide-Setup-<version>.exe`
+
+1. Run the installer executable
+2. Follow the installation wizard
+3. Launch Ren'IDE from the Start Menu or desktop shortcut
+
+**⚠️ Security Warning:** Windows SmartScreen will show "Windows protected your PC" because the application is not code-signed. This is expected behavior for open-source software.
+
+**To proceed:**
+- Click **"More info"**
+- Click **"Run anyway"**
+
+The app is safe - Windows blocks it only because it doesn't have a commercial code-signing certificate ($300-400/year).
+
+#### macOS
+
+**Download:** `renide-<version>.dmg` (choose `macos-arm64` for Apple Silicon or `macos-intel` for Intel Macs)
+
+1. Open the `.dmg` file
+2. Drag **RenIDE.app** to your **Applications** folder
+3. Launch from Applications
+
+**⚠️ Security Warning:** macOS Gatekeeper will block unsigned applications on first launch.
+
+**To run RenIDE:**
+
+**Method 1 (Recommended):**
+1. Right-click (or Control+click) **RenIDE.app** in Applications
+2. Select **"Open"** from the context menu
+3. Click **"Open"** in the security dialog that appears
+
+**Method 2 (System Settings):**
+1. Try to launch RenIDE normally (it will be blocked)
+2. Go to **System Settings → Privacy & Security**
+3. Scroll down to the **Security** section
+4. Click **"Open Anyway"** next to the RenIDE message
+5. Click **"Open"** in the confirmation dialog
+
+After the first successful launch, macOS will remember your choice and allow the app to run normally.
+
+#### Linux
+
+**Two installation options available:**
+
+##### Option 1: .deb Package (Recommended for Debian/Ubuntu)
+
+**Download:** `renide_<version>_amd64.deb`
+
+**Installation:**
+```bash
+# Install the package
+sudo apt install ./renide_<version>_amd64.deb
+
+# Launch from terminal
+renide
+
+# Or launch from your application menu
+```
+
+**Advantages:**
+- ✅ No additional dependencies required
+- ✅ Integrates with system menus and file associations
+- ✅ Automatic updates via APT package manager
+- ✅ Cleaner uninstallation (`sudo apt remove renide`)
+
+**Best for:** Ubuntu, Debian, Linux Mint, Pop!_OS, elementary OS, and other Debian-based distributions
+
+##### Option 2: AppImage (Universal - All Distros)
+
+**Download:** `renide-<version>.AppImage`
+
+**Method A: With FUSE (Traditional)**
+
+Most modern Linux distributions don't include FUSE2 by default. Install it first:
+
+```bash
+# Ubuntu/Debian/Mint
+sudo apt install libfuse2
+
+# Fedora/RHEL
+sudo dnf install fuse-libs
+
+# Arch/Manjaro
+sudo pacman -S fuse2
+
+# openSUSE
+sudo zypper install fuse
+```
+
+Then run the AppImage:
+```bash
+chmod +x renide-<version>.AppImage
+./renide-<version>.AppImage
+```
+
+**Method B: Without FUSE (Extract Mode)**
+
+If you don't want to install FUSE, use extract mode:
+
+```bash
+chmod +x renide-<version>.AppImage
+./renide-<version>.AppImage --appimage-extract-and-run
+```
+
+This extracts the AppImage to a temporary directory each time it runs (slightly slower startup, but requires no system dependencies).
+
+**Advantages:**
+- ✅ Works on all Linux distributions (Fedora, Arch, openSUSE, etc.)
+- ✅ No installation required - just download and run
+- ✅ Portable - can run from USB drive or external storage
+- ✅ Easy to test multiple versions side-by-side
+
+**Best for:** Non-Debian distributions, portable installations, or users who prefer not to install packages system-wide
+
+---
+
+### First Launch
+
+On first launch, Ren'IDE will prompt you to either:
+1. **Open an existing Ren'Py project folder**, or
+2. **Create a new project** using the 3-step wizard (name + location, resolution, theme + color)
+
+You'll also be asked to locate your Ren'Py SDK installation directory in Settings (`Ctrl+,` or `Cmd+,`) to enable the Run Game and Warp to Label features.
 
 ---
 

--- a/electron.js
+++ b/electron.js
@@ -1,4 +1,17 @@
 import { app, BrowserWindow, ipcMain, dialog, Menu, protocol, shell, safeStorage } from 'electron';
+
+// CRITICAL: Fix AppImage sandbox and shared memory issues
+// Must be called IMMEDIATELY after importing electron, before any other initialization
+// Detect AppImage environment via APPIMAGE env var or by checking if running from /tmp/.mount_*
+const isAppImage = process.env.APPIMAGE || process.env.APPDIR || /^\/tmp\/\.mount_/.test(process.execPath);
+if (isAppImage) {
+    console.log('[RenIDE] Running in AppImage mode - applying sandbox workarounds');
+    app.commandLine.appendSwitch('no-sandbox');
+    app.commandLine.appendSwitch('disable-dev-shm-usage');
+} else {
+    console.log('[RenIDE] Not running in AppImage mode');
+}
+
 import electronUpdaterPkg from 'electron-updater';
 const { autoUpdater } = electronUpdaterPkg;
 import path from 'path';
@@ -14,17 +27,6 @@ import { logger, electronLog } from './src/lib/logger.main.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-
-// Fix AppImage sandbox and shared memory issues
-// Detect AppImage environment via APPIMAGE env var or by checking if running from /tmp/.mount_*
-const isAppImage = process.env.APPIMAGE || process.env.APPDIR || /^\/tmp\/\.mount_/.test(process.execPath);
-if (isAppImage) {
-    console.log('[RenIDE] Running in AppImage mode - applying sandbox workarounds');
-    app.commandLine.appendSwitch('no-sandbox');
-    app.commandLine.appendSwitch('disable-dev-shm-usage');
-} else {
-    console.log('[RenIDE] Not running in AppImage mode');
-}
 
 // Lazy-load image generator to avoid blocking app startup if Sharp fails
 let generateGuiImages = null;

--- a/electron.js
+++ b/electron.js
@@ -15,10 +15,12 @@ import { logger, electronLog } from './src/lib/logger.main.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Fix AppImage sandbox issue: Disable Chromium sandbox when running in AppImage
+// Fix AppImage sandbox and shared memory issues
 // AppImage sets the APPIMAGE environment variable
 if (process.env.APPIMAGE) {
     app.commandLine.appendSwitch('no-sandbox');
+    // Fix shared memory errors in restricted AppImage environments
+    app.commandLine.appendSwitch('disable-dev-shm-usage');
 }
 
 // Lazy-load image generator to avoid blocking app startup if Sharp fails

--- a/electron.js
+++ b/electron.js
@@ -15,6 +15,12 @@ import { logger, electronLog } from './src/lib/logger.main.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+// Fix AppImage sandbox issue: Disable Chromium sandbox when running in AppImage
+// AppImage sets the APPIMAGE environment variable
+if (process.env.APPIMAGE) {
+    app.commandLine.appendSwitch('no-sandbox');
+}
+
 // Lazy-load image generator to avoid blocking app startup if Sharp fails
 let generateGuiImages = null;
 let sharpLoadError = null;

--- a/electron.js
+++ b/electron.js
@@ -16,11 +16,14 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Fix AppImage sandbox and shared memory issues
-// AppImage sets the APPIMAGE environment variable
-if (process.env.APPIMAGE) {
+// Detect AppImage environment via APPIMAGE env var or by checking if running from /tmp/.mount_*
+const isAppImage = process.env.APPIMAGE || process.env.APPDIR || /^\/tmp\/\.mount_/.test(process.execPath);
+if (isAppImage) {
+    console.log('[RenIDE] Running in AppImage mode - applying sandbox workarounds');
     app.commandLine.appendSwitch('no-sandbox');
-    // Fix shared memory errors in restricted AppImage environments
     app.commandLine.appendSwitch('disable-dev-shm-usage');
+} else {
+    console.log('[RenIDE] Not running in AppImage mode');
 }
 
 // Lazy-load image generator to avoid blocking app startup if Sharp fails

--- a/electron.js
+++ b/electron.js
@@ -1,16 +1,20 @@
-import { app, BrowserWindow, ipcMain, dialog, Menu, protocol, shell, safeStorage } from 'electron';
-
 // CRITICAL: Fix AppImage sandbox and shared memory issues
-// Must be called IMMEDIATELY after importing electron, before any other initialization
-// Detect AppImage environment via APPIMAGE env var or by checking if running from /tmp/.mount_*
+// Must inject flags into process.argv BEFORE importing electron
 const isAppImage = process.env.APPIMAGE || process.env.APPDIR || /^\/tmp\/\.mount_/.test(process.execPath);
 if (isAppImage) {
-    console.log('[RenIDE] Running in AppImage mode - applying sandbox workarounds');
-    app.commandLine.appendSwitch('no-sandbox');
-    app.commandLine.appendSwitch('disable-dev-shm-usage');
+    console.log('[RenIDE] Running in AppImage mode - injecting sandbox workarounds into process.argv');
+    if (!process.argv.includes('--no-sandbox')) {
+        process.argv.push('--no-sandbox');
+    }
+    if (!process.argv.includes('--disable-dev-shm-usage')) {
+        process.argv.push('--disable-dev-shm-usage');
+    }
+    console.log('[RenIDE] process.argv:', process.argv);
 } else {
     console.log('[RenIDE] Not running in AppImage mode');
 }
+
+import { app, BrowserWindow, ipcMain, dialog, Menu, protocol, shell, safeStorage } from 'electron';
 
 import electronUpdaterPkg from 'electron-updater';
 const { autoUpdater } = electronUpdaterPkg;

--- a/package.json
+++ b/package.json
@@ -137,8 +137,7 @@
       "category": "Development"
     },
     "appImage": {
-      "license": "AGPL-3.0-only",
-      "args": ["--no-sandbox"]
+      "license": "AGPL-3.0-only"
     },
     "deb": {
       "depends": []

--- a/package.json
+++ b/package.json
@@ -122,10 +122,26 @@
       "artifactName": "${name}-${version}.${ext}"
     },
     "linux": {
-      "target": ["AppImage", "deb"],
+      "target": [
+        {
+          "target": "AppImage",
+          "arch": ["x64"]
+        },
+        {
+          "target": "deb",
+          "arch": ["x64"]
+        }
+      ],
       "icon": "renide-512x512.png",
       "artifactName": "${name}-${version}.${ext}",
       "category": "Development"
+    },
+    "appImage": {
+      "license": "AGPL-3.0-only",
+      "args": ["--no-sandbox"]
+    },
+    "deb": {
+      "depends": []
     },
     "extraResources": [
       {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "renide",
   "version": "0.8.2",
-  "author": "Blue Moon Foundry Software",
+  "author": {
+    "name": "Blue Moon Foundry Software",
+    "email": "support@bluemoonfoundry.com"
+  },
   "license": "AGPL-3.0-only",
   "type": "module",
   "main": "electron.js",

--- a/package.json
+++ b/package.json
@@ -119,9 +119,10 @@
       "artifactName": "${name}-${version}.${ext}"
     },
     "linux": {
-      "target": "AppImage",
+      "target": ["AppImage", "deb"],
       "icon": "renide-512x512.png",
-      "artifactName": "${name}-${version}.${ext}"
+      "artifactName": "${name}-${version}.${ext}",
+      "category": "Development"
     },
     "extraResources": [
       {

--- a/package.json
+++ b/package.json
@@ -122,25 +122,10 @@
       "artifactName": "${name}-${version}.${ext}"
     },
     "linux": {
-      "target": [
-        {
-          "target": "AppImage",
-          "arch": ["x64"]
-        },
-        {
-          "target": "deb",
-          "arch": ["x64"]
-        }
-      ],
+      "target": ["AppImage", "deb"],
       "icon": "renide-512x512.png",
       "artifactName": "${name}-${version}.${ext}",
       "category": "Development"
-    },
-    "appImage": {
-      "license": "LICENSE"
-    },
-    "deb": {
-      "depends": []
     },
     "extraResources": [
       {

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
       "category": "Development"
     },
     "appImage": {
-      "license": "AGPL-3.0-only"
+      "license": "LICENSE"
     },
     "deb": {
       "depends": []


### PR DESCRIPTION
## Problem

Issue #146: The Linux AppImage build failed to launch with a fatal error:

```
The SUID sandbox helper binary was found, but is not configured correctly. 
Rather than run without sandboxing I'm aborting now. 
You need to make sure that /tmp/.mount_renideFvKgKt/chrome-sandbox 
is owned by root and has mode 4755.
```

This error occurred because AppImage extracts to `/tmp/.mount_*` with user ownership, but Electron's Chromium sandbox expects the `chrome-sandbox` binary to be owned by root with setuid permissions (mode 4755).

## Solution

### The Fix That Works

**Modified `electron.js` to inject `--no-sandbox` and `--disable-dev-shm-usage` flags into `process.argv` BEFORE importing Electron** (commit 757b48c).

The critical insight: flags must be present in `process.argv` before Electron initializes. Attempts to use `app.commandLine.appendSwitch()` after import were too late in the startup sequence.

```javascript
// BEFORE importing electron
const isAppImage = process.env.APPIMAGE || process.env.APPDIR || /^\/tmp\/\.mount_/.test(process.execPath);
if (isAppImage) {
    process.argv.push('--no-sandbox');
    process.argv.push('--disable-dev-shm-usage');
}

import { app, BrowserWindow, ... } from 'electron';
```

**Detection uses multiple fallback methods:**
1. `APPIMAGE` environment variable (primary)
2. `APPDIR` environment variable (alternative)
3. Check if `process.execPath` starts with `/tmp/.mount_` (AppImage mount location)

### Additional Improvements

**Added .deb package support** for better Debian/Ubuntu integration:
- `.deb` packages install to system directories with proper permissions (no sandbox issues)
- Better desktop integration (application menu, file associations)
- Proper dependency management via APT
- Recommended installation method for Debian/Ubuntu users

**Updated CI/CD workflows:**
- `release.yml` and `nightly.yml` now build and publish both AppImage and .deb artifacts
- Release notes updated to document both Linux package formats

## Changes

### Core Files Modified
- **`electron.js`**: AppImage detection and sandbox flag injection (lines 1-16)
- **`package.json`**: 
  - Added `.deb` build target alongside AppImage
  - Fixed author email requirement (needed for .deb maintainer field)
  - Linux build config simplified

### Workflow Updates
- **`.github/workflows/release.yml`**: Upload and publish both `.AppImage` and `.deb` files
- **`.github/workflows/nightly.yml`**: Upload and publish both `.AppImage` and `.deb` files

## Installation Options for End Users

### Linux

#### Option 1: .deb Package (Recommended for Debian/Ubuntu)
```bash
# Download renide_0.8.2_amd64.deb from releases
sudo apt install ./renide_0.8.2_amd64.deb
renide
```
**Pros:** No FUSE requirement, better system integration, automatic updates via APT

#### Option 2: AppImage (Universal - All Distros)

**Method A: With FUSE (traditional)**
```bash
# Install FUSE2 (Ubuntu 22.04+, Debian 12+)
sudo apt install libfuse2

# Run AppImage
chmod +x renide-0.8.2.AppImage
./renide-0.8.2.AppImage
```

**Method B: Without FUSE (extract mode)**
```bash
# No FUSE installation needed
chmod +x renide-0.8.2.AppImage
./renide-0.8.2.AppImage --appimage-extract-and-run
```

**Pros:** Works on all Linux distributions, no installation required, portable

### Windows

Download `renide-Setup-0.8.2.exe` from releases and run the installer.

**Security Warning:** Windows will show "Windows protected your PC" because the application is not code-signed. Click "More info" → "Run anyway" to proceed.

### macOS

Download `renide-0.8.2.dmg` from releases, open it, and drag RenIDE to Applications.

**Security Warning:** macOS will block unsigned applications. To run:
1. Right-click RenIDE.app → Open
2. Click "Open" in the security dialog
3. OR: System Settings → Privacy & Security → "Open Anyway"

## Testing

Tested on Ubuntu 24.04.4 LTS:
- ✅ AppImage launches without SUID sandbox error (with libfuse2 installed)
- ✅ AppImage works with `--appimage-extract-and-run` (without libfuse2)
- ✅ .deb package installs and launches correctly
- ✅ No white screen on launch
- ✅ Full application functionality verified

## Breaking Changes

None - this is a bug fix that improves compatibility.

## Related Issues

Closes #146