### PR TITLE
chore: Code quality improvements - constants, type guards, error logging (issue #139)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "renide",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "author": {
     "name": "Blue Moon Foundry Software",
     "email": "support@bluemoonfoundry.com"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,6 +67,8 @@ import {
 } from '@/lib/routeCanvasLayout';
 import { resolveWarpTarget } from '@/lib/warpTarget';
 import { logger } from '@/lib/logger';
+import { UI_TIMING } from '@/lib/constants';
+import { isSerializedSceneComposition, isSerializedImageMapComposition } from '@/lib/typeGuards';
 import {
   buildAfterWarpScript,
   getWarpVariableDrafts,
@@ -78,7 +80,7 @@ import type {
   ToastMessage, Theme, ProjectImage, RenpyAudio, Variable,
   ClipboardState, ImageMetadata, AudioMetadata, Character,
   AppSettings, ProjectSettings, StickyNote, SceneComposition, SceneSprite, ImageMapComposition, ScreenLayoutComposition, PunchlistMetadata, DiagnosticsTask, IgnoredDiagnosticRule,
-  SerializedSprite, SerializedSceneComposition, StoryCanvasGroupingMode, StoryCanvasLayoutMode, UserSnippet, MenuTemplate
+  SerializedSprite, SerializedSceneComposition, SerializedImageMapComposition, StoryCanvasGroupingMode, StoryCanvasLayoutMode, UserSnippet, MenuTemplate
 } from '@/types';
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 
@@ -86,16 +88,6 @@ import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 const SILENT_WAV_BASE64 = "UklGRigAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQQAAAAAAA==";
 
 
-interface SerializedImageRef {
-    filePath: string;
-}
-
-interface SerializedImageMapComposition {
-    screenName: string;
-    groundImage: SerializedImageRef | null;
-    hoverImage: SerializedImageRef | null;
-    hotspots: ImageMapComposition['hotspots'];
-}
 
 // --- Main App Component ---
 
@@ -1034,7 +1026,7 @@ const App: React.FC = () => {
     const timeout = setTimeout(() => {
       setIsInitialAnalysisPending(false);
       addToast('Analysis took too long and was skipped. Results may be incomplete.', 'warning');
-    }, 30_000);
+    }, UI_TIMING.ANALYSIS_TIMEOUT_MS);
     return () => clearTimeout(timeout);
   }, [isInitialAnalysisPending, addToast]);
 
@@ -1790,37 +1782,48 @@ const App: React.FC = () => {
               if (projectData.settings.sceneCompositions) {
                   const restoredScenes: Record<string, SceneComposition> = {};
                   Object.entries(projectData.settings.sceneCompositions).forEach(([id, sc]) => {
-                      const comp = sc as unknown as SerializedSceneComposition;
-                      restoredScenes[id] = {
-                          background: comp.background ? rehydrateSprite(comp.background) : null,
-                          sprites: comp.sprites.map(rehydrateSprite),
-                          resolution: comp.resolution,
-                      };
+                      if (isSerializedSceneComposition(sc)) {
+                          restoredScenes[id] = {
+                              background: sc.background ? rehydrateSprite(sc.background) : null,
+                              sprites: sc.sprites.map(rehydrateSprite),
+                              resolution: sc.resolution,
+                          };
+                      } else {
+                          logger.warn('Skipping malformed scene composition entry', { id, sc });
+                      }
                   });
                   setSceneCompositions(restoredScenes);
                   setSceneNames(projectData.settings.sceneNames || {});
-              } else if ((projectData.settings as unknown as Record<string, unknown>).sceneComposition) {
-                  // Migration for legacy single scene (pre-multi-scene format)
-                  const defaultId = 'scene-default';
-                  setSceneCompositions({ [defaultId]: rehydrateScene((projectData.settings as unknown as Record<string, unknown>).sceneComposition as SerializedSceneComposition) });
-                  setSceneNames({ [defaultId]: 'Default Scene' });
               } else {
-                  setSceneCompositions({});
-                  setSceneNames({});
+                  // Migration for legacy single scene (pre-multi-scene format)
+                  const settings = projectData.settings as unknown as Record<string, unknown>;
+                  const legacyScene = settings.sceneComposition;
+                  if (isSerializedSceneComposition(legacyScene)) {
+                      const defaultId = 'scene-default';
+                      setSceneCompositions({ [defaultId]: rehydrateScene(legacyScene) });
+                      setSceneNames({ [defaultId]: 'Default Scene' });
+                  } else {
+                      setSceneCompositions({});
+                      setSceneNames({});
+                  }
               }
 
               // Restore ImageMap Compositions
               if (projectData.settings.imagemapCompositions) {
                   const restoredImagemaps: Record<string, ImageMapComposition> = {};
-                  Object.entries(projectData.settings.imagemapCompositions as Record<string, SerializedImageMapComposition>).forEach(([id, im]) => {
-                      const groundImg = im.groundImage ? imgMap.get(im.groundImage.filePath) : null;
-                      const hoverImg = im.hoverImage ? imgMap.get(im.hoverImage.filePath) : null;
-                      restoredImagemaps[id] = {
-                          screenName: im.screenName,
-                          groundImage: groundImg || null,
-                          hoverImage: hoverImg || null,
-                          hotspots: im.hotspots
-                      };
+                  Object.entries(projectData.settings.imagemapCompositions).forEach(([id, im]) => {
+                      if (isSerializedImageMapComposition(im)) {
+                          const groundImg = im.groundImage ? imgMap.get(im.groundImage.filePath) : null;
+                          const hoverImg = im.hoverImage ? imgMap.get(im.hoverImage.filePath) : null;
+                          restoredImagemaps[id] = {
+                              screenName: im.screenName,
+                              groundImage: groundImg || null,
+                              hoverImage: hoverImg || null,
+                              hotspots: im.hotspots
+                          };
+                      } else {
+                          logger.warn('Skipping malformed imagemap composition entry', { id, im });
+                      }
                   });
                   setImagemapCompositions(restoredImagemaps);
               } else {
@@ -2540,9 +2543,9 @@ const App: React.FC = () => {
         diagnosticsTasks,
         ignoredDiagnostics,
         dismissedImplicitVariableHint: dismissedImplicitVarHint,
-        sceneCompositions: serializableScenes as unknown as Record<string, SceneComposition>,
+        sceneCompositions: serializableScenes,
         sceneNames,
-        imagemapCompositions: serializableImagemaps as unknown as Record<string, ImageMapComposition>,
+        imagemapCompositions: serializableImagemaps,
         screenLayoutCompositions,
         scannedImagePaths: Array.from(imageScanDirectories.keys()),
         scannedAudioPaths: Array.from(audioScanDirectories.keys()),
@@ -3198,7 +3201,7 @@ const App: React.FC = () => {
           // Small timeout to ensure canvas is rendered if switching tabs
           setTimeout(() => {
               setCenterOnBlockRequest({ blockId, key: Date.now() });
-          }, 50);
+          }, UI_TIMING.CANVAS_CENTER_DELAY_MS);
       } else {
           // Attempt to find sticky note
           const note = stickyNotes.find(n => n.id === target);

--- a/src/components/AudioEditorView.tsx
+++ b/src/components/AudioEditorView.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback, memo } from 'react';
+import { UI_TIMING } from '@/lib/constants';
+import { logger } from '@/lib/logger';
 import type { RenpyAudio, AudioMetadata } from '@/types';
 
 interface AudioEditorViewProps {
@@ -220,10 +222,11 @@ const AudioEditorView: React.FC<AudioEditorViewProps> = ({ audio, metadata, onSa
     try {
       await onSaveMetadata(currentFilePath, newMetadata);
       setSaveState('saved');
-      savedTimerRef.current = setTimeout(() => setSaveState('idle'), 2000);
-    } catch {
+      savedTimerRef.current = setTimeout(() => setSaveState('idle'), UI_TIMING.SAVE_STATE_RESET_MS);
+    } catch (err) {
+      logger.error('Failed to save audio metadata', err);
       setSaveState('error');
-      savedTimerRef.current = setTimeout(() => setSaveState('idle'), 2000);
+      savedTimerRef.current = setTimeout(() => setSaveState('idle'), UI_TIMING.SAVE_STATE_RESET_MS);
     }
   };
 

--- a/src/components/CanvasNodeContextMenu.tsx
+++ b/src/components/CanvasNodeContextMenu.tsx
@@ -5,6 +5,7 @@
  */
 import React, { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
+import { Z_INDEX } from '@/lib/constants';
 
 interface CanvasNodeContextMenuProps {
   x: number;
@@ -52,8 +53,8 @@ const CanvasNodeContextMenu: React.FC<CanvasNodeContextMenuProps> = ({
   return createPortal(
     <div
       ref={menuRef}
-      className="fixed z-[9999] bg-white dark:bg-gray-800 rounded-md shadow-2xl border border-gray-200 dark:border-gray-700 w-56 overflow-hidden"
-      style={{ top: y, left: x }}
+      className="fixed bg-white dark:bg-gray-800 rounded-md shadow-2xl border border-gray-200 dark:border-gray-700 w-56 overflow-hidden"
+      style={{ top: y, left: x, zIndex: Z_INDEX.CONTEXT_MENU }}
       onContextMenu={e => e.preventDefault()}
       onPointerDown={e => e.stopPropagation()}
       onMouseDown={e => e.stopPropagation()}

--- a/src/components/FileExplorerPanel.tsx
+++ b/src/components/FileExplorerPanel.tsx
@@ -8,6 +8,7 @@
  */
 
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { logger } from '@/lib/logger';
 import { useVirtualList } from '@/hooks/useVirtualList';
 
 // py-1 (4+4) + h-5 icon (20px) = 28px per row
@@ -373,7 +374,9 @@ const FileExplorerPanel: React.FC<FileExplorerPanelProps> = ({
               if (sourcePaths.some(p => node.path.startsWith(p) && node.path.length > p.length)) return;
               onMoveNode(sourcePaths, node.path);
           }
-      } catch { /* ignore */ }
+      } catch (err) {
+          logger.debug('Could not parse drag-drop data transfer payload', err);
+      }
   }, [onMoveNode]);
 
   return (

--- a/src/components/FirstRunTutorial.tsx
+++ b/src/components/FirstRunTutorial.tsx
@@ -8,6 +8,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { useModalAccessibility } from '@/hooks/useModalAccessibility';
+import { UI_TIMING, Z_INDEX, TUTORIAL_DIMENSIONS } from '@/lib/constants';
 
 const TUTORIAL_STORAGE_KEY = 'renpy-ide-tutorial-completed';
 
@@ -103,7 +104,7 @@ const FirstRunTutorial: React.FC<FirstRunTutorialProps> = ({ onComplete, forceSh
       // Small delay to let the UI render first
       const timer = setTimeout(() => {
         setShowWelcome(true);
-      }, 1000);
+      }, UI_TIMING.TUTORIAL_SHOW_DELAY_MS);
       return () => clearTimeout(timer);
     }
   }, []); // Run once on mount
@@ -136,8 +137,8 @@ const FirstRunTutorial: React.FC<FirstRunTutorialProps> = ({ onComplete, forceSh
       setSpotlightRect(null);
       const viewportHeight = window.innerHeight;
       const viewportWidth = window.innerWidth;
-      const messageWidth = 320;
-      const messageHeight = 200;
+      const messageWidth = TUTORIAL_DIMENSIONS.MESSAGE_WIDTH;
+      const messageHeight = TUTORIAL_DIMENSIONS.MESSAGE_HEIGHT;
       setMessagePosition({
         top: viewportHeight / 2 - messageHeight / 2,
         left: viewportWidth / 2 - messageWidth / 2,
@@ -146,7 +147,7 @@ const FirstRunTutorial: React.FC<FirstRunTutorialProps> = ({ onComplete, forceSh
     }
 
     let retryCount = 0;
-    const maxRetries = 30; // Try for 3 seconds (30 * 100ms)
+    const maxRetries = UI_TIMING.TUTORIAL_MAX_RETRIES;
 
     const updateSpotlight = () => {
       const element = document.querySelector(step.targetSelector);
@@ -163,8 +164,8 @@ const FirstRunTutorial: React.FC<FirstRunTutorialProps> = ({ onComplete, forceSh
         // Calculate message position based on step position preference
         const viewportHeight = window.innerHeight;
         const viewportWidth = window.innerWidth;
-        const messageWidth = 320;
-        const messageHeight = 200;
+        const messageWidth = TUTORIAL_DIMENSIONS.MESSAGE_WIDTH;
+        const messageHeight = TUTORIAL_DIMENSIONS.MESSAGE_HEIGHT;
 
         let top = rect.top;
         let left = rect.left;
@@ -201,14 +202,14 @@ const FirstRunTutorial: React.FC<FirstRunTutorialProps> = ({ onComplete, forceSh
         // Element not found, try again after a short delay (up to maxRetries)
         retryCount++;
         if (retryCount < maxRetries) {
-          setTimeout(updateSpotlight, 100);
+          setTimeout(updateSpotlight, UI_TIMING.TUTORIAL_SPOTLIGHT_RETRY_MS);
         } else {
           // Element not found after retries, show message in center without spotlight
           setSpotlightRect(null);
           const viewportHeight = window.innerHeight;
           const viewportWidth = window.innerWidth;
-          const messageWidth = 320;
-          const messageHeight = 200;
+          const messageWidth = TUTORIAL_DIMENSIONS.MESSAGE_WIDTH;
+          const messageHeight = TUTORIAL_DIMENSIONS.MESSAGE_HEIGHT;
           setMessagePosition({
             top: viewportHeight / 2 - messageHeight / 2,
             left: viewportWidth / 2 - messageWidth / 2,
@@ -256,7 +257,8 @@ const FirstRunTutorial: React.FC<FirstRunTutorialProps> = ({ onComplete, forceSh
   if (showWelcome) {
     return (
       <div
-        className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-[200]"
+        className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center"
+        style={{ zIndex: Z_INDEX.TUTORIAL_OVERLAY }}
         onClick={handleSkip}
         {...welcomeModalProps}
       >
@@ -301,9 +303,9 @@ const FirstRunTutorial: React.FC<FirstRunTutorialProps> = ({ onComplete, forceSh
   const isLastStep = currentStepIndex === TOUR_STEPS.length - 1;
 
   return (
-    <div className="fixed inset-0 z-[200] pointer-events-none">
+    <div className="fixed inset-0 pointer-events-none" style={{ zIndex: Z_INDEX.TUTORIAL_OVERLAY }}>
       {/* Semi-transparent overlay with spotlight cutout */}
-      <svg className="absolute inset-0 w-full h-full pointer-events-auto" style={{ zIndex: 200 }}>
+      <svg className="absolute inset-0 w-full h-full pointer-events-auto" style={{ zIndex: Z_INDEX.TUTORIAL_OVERLAY }}>
         <defs>
           <mask id="spotlight-mask">
             <rect x="0" y="0" width="100%" height="100%" fill="white" />
@@ -339,7 +341,7 @@ const FirstRunTutorial: React.FC<FirstRunTutorialProps> = ({ onComplete, forceSh
             left: spotlightRect.left,
             width: spotlightRect.width,
             height: spotlightRect.height,
-            zIndex: 201,
+            zIndex: Z_INDEX.TUTORIAL_SPOTLIGHT_BORDER,
           }}
         />
       )}
@@ -351,8 +353,8 @@ const FirstRunTutorial: React.FC<FirstRunTutorialProps> = ({ onComplete, forceSh
           style={{
             top: messagePosition.top,
             left: messagePosition.left,
-            width: '320px',
-            zIndex: 202,
+            width: `${TUTORIAL_DIMENSIONS.MESSAGE_WIDTH}px`,
+            zIndex: Z_INDEX.TUTORIAL_MESSAGE,
           }}
         >
           <h3 className="text-lg font-bold text-gray-900 dark:text-gray-100 mb-2">

--- a/src/components/ImageEditorView.tsx
+++ b/src/components/ImageEditorView.tsx
@@ -8,6 +8,8 @@
  */
 
 import React, { useState, useEffect, useMemo, useRef, useCallback, memo } from 'react';
+import { UI_TIMING } from '@/lib/constants';
+import { logger } from '@/lib/logger';
 import type { ProjectImage, ImageMetadata } from '@/types';
 
 interface ImageEditorViewProps {
@@ -195,10 +197,11 @@ const ImageEditorView: React.FC<ImageEditorViewProps> = ({ image, allImages, met
             projectSubfolder: subfolder.trim(),
         });
         setSaveState('saved');
-        savedTimerRef.current = setTimeout(() => setSaveState('idle'), 2000);
-    } catch {
+        savedTimerRef.current = setTimeout(() => setSaveState('idle'), UI_TIMING.SAVE_STATE_RESET_MS);
+    } catch (err) {
+        logger.error('Failed to save image metadata', err);
         setSaveState('error');
-        savedTimerRef.current = setTimeout(() => setSaveState('idle'), 2000);
+        savedTimerRef.current = setTimeout(() => setSaveState('idle'), UI_TIMING.SAVE_STATE_RESET_MS);
     }
   };
 

--- a/src/components/MenuConstructor.tsx
+++ b/src/components/MenuConstructor.tsx
@@ -8,6 +8,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
+import { logger } from '@/lib/logger';
 import type { RenpyAnalysisResult } from '@/types';
 import CodeActionButtons from './CodeActionButtons';
 import type * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
@@ -203,7 +204,8 @@ const MenuConstructor: React.FC<MenuConstructorProps> = ({ analysisResult, activ
             setCaption(newCaption);
             setChoices(newChoices);
             setParseError(null);
-        } catch {
+        } catch (err) {
+            logger.debug('Menu code parse failed, disabling visual editing', err);
             setParseError("Cannot parse complex or invalid code. Visual editing disabled.");
         }
     };

--- a/src/hooks/useRenpyAnalysis.ts
+++ b/src/hooks/useRenpyAnalysis.ts
@@ -12,6 +12,7 @@ import { getTripleQuotedLineMask } from '@/lib/renpyTripleQuotes';
 import { isReservedRenpyName } from '@/lib/renpyNames';
 import { collectRenpyHasLabelGuards, isJumpGuardedByHasLabel } from '@/lib/renpyLabelGuards';
 import { buildRouteGraph, computeLayeredLayoutGeneric, type LayoutConfig } from '@/lib/graphLayout';
+import { logger } from '@/lib/logger';
 
 /**
  * Minimal block shape used by the analysis engine — only the fields it actually reads.
@@ -732,7 +733,8 @@ const getAnalysisWorker = (): Worker | null => {
         new URL('../workers/renpyAnalysis.worker.ts', import.meta.url),
         { type: 'module' }
       );
-    } catch {
+    } catch (err) {
+      logger.warn('Failed to create analysis worker; falling back to synchronous analysis', err);
       return null;
     }
   }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,22 @@
+export const UI_TIMING = {
+  TUTORIAL_SHOW_DELAY_MS: 1000,
+  TUTORIAL_SPOTLIGHT_RETRY_MS: 100,
+  TUTORIAL_MAX_RETRIES: 30,
+  SAVE_STATE_RESET_MS: 2000,
+  CANVAS_CENTER_DELAY_MS: 50,
+  ANALYSIS_TIMEOUT_MS: 30_000,
+} as const;
+
+export const Z_INDEX = {
+  // Context menus sit above canvas chrome but below modals
+  CONTEXT_MENU: 40,
+  // Tutorial overlay must cover all other UI layers
+  TUTORIAL_OVERLAY: 200,
+  TUTORIAL_SPOTLIGHT_BORDER: 201,
+  TUTORIAL_MESSAGE: 202,
+} as const;
+
+export const TUTORIAL_DIMENSIONS = {
+  MESSAGE_WIDTH: 320,
+  MESSAGE_HEIGHT: 200,
+} as const;

--- a/src/lib/typeGuards.ts
+++ b/src/lib/typeGuards.ts
@@ -1,0 +1,21 @@
+import type { SerializedSceneComposition, SerializedImageMapComposition } from '@/types';
+
+export function isSerializedSceneComposition(obj: unknown): obj is SerializedSceneComposition {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    'sprites' in obj &&
+    Array.isArray((obj as Record<string, unknown>).sprites)
+  );
+}
+
+export function isSerializedImageMapComposition(obj: unknown): obj is SerializedImageMapComposition {
+  return (
+    typeof obj === 'object' &&
+    obj !== null &&
+    'screenName' in obj &&
+    typeof (obj as Record<string, unknown>).screenName === 'string' &&
+    'hotspots' in obj &&
+    Array.isArray((obj as Record<string, unknown>).hotspots)
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -962,9 +962,9 @@ export interface ProjectSettings {
   punchlistMetadata?: Record<string, PunchlistMetadata>;
   diagnosticsTasks?: DiagnosticsTask[];
   ignoredDiagnostics?: IgnoredDiagnosticRule[];
-  sceneCompositions?: Record<string, SceneComposition>;
+  sceneCompositions?: Record<string, SerializedSceneComposition>;
   sceneNames?: Record<string, string>;
-  imagemapCompositions?: Record<string, ImageMapComposition>;
+  imagemapCompositions?: Record<string, SerializedImageMapComposition>;
   screenLayoutCompositions?: Record<string, ScreenLayoutComposition>;
   scannedImagePaths?: string[];
   scannedAudioPaths?: string[];
@@ -1083,6 +1083,19 @@ export interface SerializedSceneComposition {
   background: SerializedSprite | null;
   sprites: SerializedSprite[];
   resolution?: { width: number; height: number };
+}
+
+/** File path reference used when serializing image map compositions for persistence. */
+export interface SerializedImageRef {
+  filePath: string;
+}
+
+/** Serialized image map composition for persistence (paths only, no loaded image objects). */
+export interface SerializedImageMapComposition {
+  screenName: string;
+  groundImage: SerializedImageRef | null;
+  hoverImage: SerializedImageRef | null;
+  hotspots: ImageMapHotspot[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #139

- **`src/lib/constants.ts`** (new): Centralizes magic numbers — `UI_TIMING` (timeouts/delays), `Z_INDEX` (layering values), and `TUTORIAL_DIMENSIONS` (message card size). Consumed by `FirstRunTutorial`, `ImageEditorView`, `AudioEditorView`, `CanvasNodeContextMenu`, and `App.tsx`.
- **`src/lib/typeGuards.ts`** (new): `isSerializedSceneComposition` and `isSerializedImageMapComposition` type guards replace `as unknown as` casts during project load. Malformed entries now log a warning and are skipped instead of crashing.
- **`src/types.ts`**: Moved `SerializedImageRef` and `SerializedImageMapComposition` out of `App.tsx` (local scope) and into the shared types file. Updated `ProjectSettings.sceneCompositions` and `ProjectSettings.imagemapCompositions` to correctly use the serialized types, eliminating two more unsafe casts on the save path.
- **Catch block logging**: Added `logger` calls to all previously silent catch blocks in `FileExplorerPanel`, `MenuConstructor`, `ImageEditorView`, `AudioEditorView`, and `useRenpyAnalysis`. Levels: `debug` for expected/ignorable failures, `error` for save failures, `warn` for worker creation failure.
- **Z-index**: Replaced `z-[9999]` in `CanvasNodeContextMenu` with `Z_INDEX.CONTEXT_MENU` (40) via inline style, consistent with the rest of the z-index scale.

## Test plan

- [x] Open an existing project — scene and imagemap compositions restore correctly
- [x] Save project settings — no TypeScript errors, compositions persist as expected
- [x] Drag a file in Project Explorer to a new folder — operation works, no console errors
- [x] Open Menu Constructor with valid and invalid code — parse error banner appears for invalid code
- [x] Save metadata in Image Editor and Audio Editor — saved/error states toggle correctly
- [x] Right-click a node on Flow or Choices Canvas — context menu appears at correct z-level (below modals)
- [x] First-run tutorial launches and spotlight/message card renders at correct z-level

🤖 Generated with [Claude Code](https://claude.com/claude-code)