### PR TITLE
feat: Flow Canvas scene image thumbnails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,242 +7,88 @@ Vangard Ren'Py IDE (Ren'IDE) is an Electron + React/TypeScript desktop applicati
 
 ## Project Structure
 
-All source code is organized under `src/` with path aliases configured for clean imports:
-
 ```
 src/
-├── App.tsx                 # Main application component (5,320 lines - state hub)
+├── App.tsx                 # Main application component — state hub (~5k lines)
 ├── index.tsx               # React entry point
 ├── types.ts                # TypeScript type definitions (single source of truth)
-├── components/             # React UI components (79 files)
-├── hooks/                  # Custom React hooks (17 files)
-├── lib/                    # Utility functions and algorithms (29 files)
+├── components/             # React UI components
+├── hooks/                  # Custom React hooks
+├── lib/                    # Utility functions and algorithms
 ├── contexts/               # React context providers (SearchContext)
 ├── test/                   # Test setup, mocks, and test files
 └── workers/                # Web Workers (renpyAnalysis.worker.ts)
 ```
 
-**Import Convention:** Use the `@/` path alias for all imports:
+**Import Convention:** Use the `@/` path alias for all imports (never relative `../`):
 ```typescript
 import type { Block } from '@/types';
 import { useHistory } from '@/hooks/useHistory';
-import Toolbar from '@/components/Toolbar';
-import { createId } from '@/lib/createId';
 ```
 
-Root-level files (outside src/):
-- `electron.js` - Electron main process (Node.js runtime)
-- `preload.js` - Electron preload script (IPC bridge)
-- `vite.config.ts`, `tsconfig.json`, `eslint.config.js` - Build configuration
-- `package.json`, `.gitignore`, `README.md`, etc.
+Root-level: `electron.js` (main process), `preload.js` (IPC bridge), `vite.config.ts`, `tsconfig.json`.
 
 ## Commands
 ```bash
-npm run dev                        # Vite dev server (http://localhost:5173)
-npm run electron:start             # Build + launch full Electron app
-npm run build                      # Production build to dist/
-npm run dist                       # Package to release/ (DMG/NSIS/AppImage)
-npm test                           # Vitest once
-npm run test:watch                 # Vitest watch mode
-npx vitest run src/hooks/useHistory.test.ts  # Run a single test file
-npm run test:coverage              # Coverage report (v8)
-npm run lint:fix                   # ESLint auto-fix
+npm run dev                # Vite dev server (http://localhost:5173)
+npm run electron:start     # Build + launch full Electron app
+npm run build              # Production build to dist/
+npm test                   # Vitest once
+npm run test:watch         # Vitest watch mode
+npm run lint:fix           # ESLint auto-fix
 ```
 
 ## Architecture & State
 
 ### State Hub (`App.tsx`)
-All core state lives in `App.tsx` using `useImmer` or `useState`. Key state categories:
+All core state lives in `App.tsx` using `useImmer` or `useState`.
 
 | State | Hook | Persisted To |
 |-------|------|-------------|
-| `blocks[]` | `useHistory` (undo/redo) | Individual `.rpy` files (content) + `game/project.ide.json` (positions) |
+| `blocks[]` | `useHistory` (undo/redo) | Individual `.rpy` files + `game/project.ide.json` (positions) |
 | `groups[]`, `stickyNotes[]`, `routeStickyNotes[]`, `choiceStickyNotes[]` | `useImmer` | `game/project.ide.json` |
 | `projectImages`, `projectAudios` | `useState` (Maps) | `game/project.ide.json` (metadata only) |
 | `sceneCompositions`, `imagemapCompositions`, `screenLayoutCompositions` | `useImmer` | `game/project.ide.json` |
 | `diagnosticsTasks`, `ignoredDiagnostics`, `characterProfiles` | `useImmer` | `game/project.ide.json` |
 | `analysisResult`, `diagnosticsResult` | derived/computed | Never — recalculated on change |
 | `openTabs[]`, `activeTabId`, `selectedBlockIds[]` | `useState` | Never — session-only |
-| `menuTemplates` | `useState` | `game/project.ide.json` |
 
-App-level settings (theme, font, layout prefs) persist to `userData/app-settings.json`. API keys are stored via Electron's `safeStorage` (encrypted OS keychain), accessed through `app:load-api-keys` / `app:save-api-key` IPC handlers.
+App-level settings persist to `userData/app-settings.json`. API keys use Electron's `safeStorage` via `app:load-api-keys` / `app:save-api-key` IPC.
 
-**Undo/redo** (`useHistory`) only covers `blocks[]`. It does not affect editor text (Monaco handles that), canvas transforms, or project settings. It also prevents undoing past the initial state (`canUndo` only if `past.length > 1`).
-
-### Block Lifecycle
-1. User opens `CreateBlockModal` → inputs name, type (`story|screen|config`), folder
-2. `handleCreateBlockConfirm()` writes file to disk via IPC, pushes a new `Block` to state, opens an editor tab
-3. `debouncedBlocks` (500ms debounce) feeds `useRenpyAnalysis` — **only passes `{ id, content, filePath }`**, not position/width/color, so drag events never trigger re-analysis
-4. Analysis extracts the first label name → sets `block.title`; color is deterministically derived from title via string hash
-5. Block positions persist to `game/project.ide.json` on Save All (Ctrl+S), dirty-tab close, and app exit — not on a timer
+`debouncedBlocks` (500ms) feeds `useRenpyAnalysis` with only `{ id, content, filePath }` — drag/position changes never trigger re-analysis.
 
 ### IPC Pattern
-All cross-process calls use `namespace:action` strings:
+All cross-process calls use `namespace:action` strings. Namespaces: `fs`, `project`, `dialog`, `game`, `renpy`, `app`, `path`, `shell`, `explorer`.
 ```typescript
-// Renderer
-await window.electronAPI.fs.readFile(path);
-// Main (electron.js)
-ipcMain.handle('fs:readFile', async (event, path) => fs.readFile(path, 'utf-8'));
+await window.electronAPI.fs.readFile(path);           // renderer
+ipcMain.handle('fs:readFile', async (_, p) => ...);   // main
 ```
-Namespaces: `fs`, `project`, `dialog`, `game`, `renpy`, `app`, `path`, `shell`, `explorer`. Async push events from main (file watcher, game lifecycle) arrive via `ipcRenderer.on` and are exposed as `electronAPI.on*` callbacks: `onLoadProgress`, `onFileChangedExternally`, `onGameStarted`, `onGameStopped`, `onGameError`, `onMenuCommand`, `onCheckUnsavedChangesBeforeExit`, `onShowExitModal`, `onSaveIdeStateBeforeQuit`.
-
-Key recent IPC additions:
-- `project:refresh` — reconciles blocks/images/audios with disk state (for external file changes)
-- `app:load-api-keys` / `app:save-api-key` — encrypted API key storage via Electron's safeStorage
-
-### External File Watcher
-Main process watches the project folder for `.rpy` changes with 400ms debounce. If the block is clean in the editor, it auto-reloads silently. If dirty, it shows a persistent warning bar ("Reload" / "Keep"). Main suppresses change events for 3 seconds after the app writes a file to avoid false positives. Related feature: **Refresh Project** (File menu, explorer context menu) manually reconciles all files/assets with disk state via `project:refresh` IPC.
-
-### Tab System
-`openTabs: EditorTab[]` tracks open panels. Tabs mount lazily on first activation, then stay mounted-but-hidden to preserve Monaco scroll/state. Valid tab types: `canvas`, `route-canvas`, `choice-canvas`, `editor`, `image`, `audio`, `character`, `scene-composer`, `imagemap-composer`, `screen-layout-composer`, `markdown`, `stats`, `diagnostics`, `punchlist` (legacy, now diagnostics).
-
-### Context Providers
-Only `SearchContext` wraps the app in `App.tsx`:
-- **`SearchContext`** — offloads search state from App to avoid prop drilling; delegates to `electronAPI.searchInProject` for ripgrep-backed search.
-
-**Note:** Previous versions had `AssetContext`, `FileSystemContext`, and `ToastContext`, but these were removed in commit 381fb02 (April 2025). All asset state, file system operations, and toast management are now handled directly in `App.tsx` via `useState`/`useImmer` for simpler state flow.
-
-### Memoization Discipline
-`App.tsx` aggressively memoizes derived arrays/sets to prevent canvas re-renders on unrelated state changes:
-```typescript
-const imagesArray = useMemo(() => Array.from(images.values()), [images]);
-const menuLabels  = useMemo(() => new Set(Object.keys(analysisResult.labels)), [analysisResult.labels]);
-```
-Without this, every tab switch recalculates arrays and re-renders the full canvas.
 
 ### Three Canvases
-All three canvases share the same pointer-event drag model: global `pointermove`/`pointerup` listeners are attached on `pointerdown` and removed on release — no React synthetic events during drag for performance. Drag state is tracked in a local state machine (`dragging-blocks`, `dragging-groups`, `dragging-notes`), initial positions stored in a Map, deltas applied live.
+All canvases use native pointer events (`pointerdown`/`pointermove`/`pointerup`) with global listeners — no React synthetic events during drag.
 
 | | ProjectCanvas | FlowCanvas | ChoicesCanvas |
 |--|-------------|-------------|--------------|
-| **Display Name** | Project Canvas | Flow Canvas | Choices Canvas |
-| **Component File** | `StoryCanvas.tsx` | `RouteCanvas.tsx` | `ChoiceCanvas.tsx` |
+| **Component** | `StoryCanvas.tsx` | `RouteCanvas.tsx` | `ChoiceCanvas.tsx` |
 | **Granularity** | Block-level (`.rpy` files) | Label-level | Label-level |
 | **Nodes** | `blocks[]` | `labelNodes[]` | `labelNodes[]` |
 | **Edges** | `analysisResult.links[]` | `routeLinks[]` | `routeLinks[]` + choice pills |
-| **Layout** | `storyCanvasLayout.ts` (4 algorithms) | `routeCanvasLayout.ts` | `routeCanvasLayout.ts` |
-| **Visual uniqueness** | Hash-derived block colors, block-type icons, groups | Hub/branch/menu-heavy badges | Choice pills (6-color rotation), dialogue snippets |
 
-**Note:** Display names changed to Project/Flow/Choices in v0.7.1 for better clarity with non-technical users. Internal component files and state variables still use original names (Story/Route/Choice) to avoid breaking changes.
+> Internal files/variables use Story/Route/Choice; display names are Project/Flow/Choices (changed v0.7.1).
 
-`RenpyAnalysisResult` is the central data structure connecting analysis to all three canvases. Beyond labels/jumps/characters/screens, it carries `labelNodes[]`, `routeLinks[]`, and `identifiedRoutes[]` specifically for Flow/Choices Canvas rendering.
-
-### Key Hooks
-| Hook | Purpose |
-|------|---------|
-| `useHistory` | Undo/redo stack for `blocks[]` only |
-| `useRenpyAnalysis` | Heavy parser — populates `RenpyAnalysisResult` including all canvas data; takes only `{ id, content, filePath }` to avoid drag-triggered re-runs |
-| `useDiagnostics` | Computes errors/warnings/info; supports rule suppression via `ignoredDiagnostics` |
-| `useFileSystemManager` | File tree CRUD, clipboard (copy/cut), drag-drop routing |
-| `usePerformanceMetrics` | Per-frame render/layout timing; records FPS spikes |
-| `useVirtualList` | Lazy-renders long lists (file explorer) |
-| `useSnippetLoader` | Merges snippets from three sources: built-in `snippets/default-snippets.json`, user global `~/.vangard-ide/snippets/custom.json`, project-specific `<project>/.vangard/snippets.json` |
-| `useDebounce` | Generic 500ms debounce (blocks feed into analysis via this) |
-| `useCanvasFps` | Measures canvas rendering FPS (60-frame rolling average) for IDE performance metrics |
-| `useProjectColorScan` | Scans all block content for hex color literals to populate "Project Theme" palette |
-| `useModalAccessibility` | Focus trap, ESC handling, ARIA for modals |
-
-### Monaco & Syntax Highlighting
-Monaco uses two layers of Ren'Py language support:
-1. **TextMate tokenization** — `textmateGrammar.ts` loads Oniguruma WASM and parses `renpy.tmLanguage.json` (custom grammar), bridged to Monaco via `createTextMateTokensProvider()`. Lazily initialized on first editor mount.
-2. **Semantic token overlays** — `renpySemanticTokens.ts` defines 9 token types (labels, characters, images, screens, variables — each in known/unknown variants) and colors them based on live `RenpyAnalysisResult` data.
-
-The app supports 11 themes (`system`, `light`, `dark`, `solarized-light`, `solarized-dark`, `colorful`, `colorful-light`, `neon-dark`, `ocean-dark`, `candy-light`, `forest-light`) defined as the `Theme` type in `types.ts`. Monaco receives `editorTheme` prop and maps to its own dark/light mode setting.
-
-### Key `lib/` Modules
-| Module | Purpose |
-|--------|---------|
-| `storyCanvasLayout.ts` | Auto-layout algorithms (flow-lr, flow-td, connected-components, clustered-flow) |
-| `routeCanvasLayout.ts` | Label-node positioning for Route Canvas |
-| `graphLayout.ts` | Generic DAG layout + route enumeration for menus/routes |
-| `renpyValidator.ts` | Syntax validation (triple quotes, logical lines, label guards) |
-| `renpyCompletionProvider.ts` | Monaco autocomplete: labels, characters, screens, variables |
-| `renpySemanticTokens.ts` | Syntax highlighting via Monaco semantic tokens |
-| `screenCodeGenerator.ts` | Converts Screen Layout Composer tree → Ren'Py screen code |
-| `textmateGrammar.ts` | TextMate tokenization with Oniguruma WASM for syntax highlighting |
-| `colorUtils.js` | Color conversion utilities and palette definitions |
-
-## Major Features & Recent Updates
-
-### Scene Composer Visual Effects (April 2025)
-The Scene Composer now includes a comprehensive Visual Effects system with shader support:
-- **Color grading**: saturation, brightness, contrast, invert sliders
-- **Color modes**: tint (single color overlay), colorize (remap black→white gradient)
-- **Matrix presets**: Categorized preset effects (Night, Sunset, Sepia, Greyscale, Noir, Faded, Silhouette, etc.) via `MatrixPresetPopover`
-- **Custom shader uniforms**: extensible shader system via `activeShader` and `shaderUniforms` in `SceneSprite` type
-- **Layer locking**: prevent accidental edits to sprites
-- **Inline layer actions**: Delete/Make BG buttons now appear as hover-reveal icons on layer rows
-
-### Audio Player (April 2025)
-Custom audio player in AudioEditorView replaces native `<audio controls>`:
-- **Web Audio API integration**: glowing play/pause button with custom seek bar
-- **64-bar equalizer**: cyan→blue→violet gradient with peak dots and scanline overlay
-- **Volume control**: custom slider with visual feedback
-- **Flex-row layout**: player on left, metadata sidebar on right (matches ImageEditorView)
-
-### Accessibility & Keyboard Navigation (April 2025)
-Full keyboard navigation for all three canvases:
-- **Global shortcuts**: `Ctrl+G` / `Cmd+G` opens Go-to-Label command palette (auto-zooms to 100%)
-- **Canvas navigation**: Tab/Shift+Tab for focus cycling, Arrow keys for spatial navigation, Enter to open in editor, Escape to deselect
-- **ARIA labels**: all canvas blocks/nodes have descriptive labels for screen readers (NVDA, VoiceOver, JAWS)
-- **Focus indicators**: visible outlines for keyboard-only users
-
-### First-Run Tutorial (April 2025)
-6-step interactive onboarding with SVG spotlight animations:
-1. Welcome + Project creation
-2. Three canvas types (Story/Route/Choice)
-3. Story Canvas file-level view
-4. New Scene button
-5. Story Elements panel
-6. Final tips (keyboard shortcuts)
-- Stored in localStorage; replay via Help → Show Tutorial
-- Keyboard nav: Escape to skip, Enter/arrows to navigate
-
-### Markdown Preview (April 2025)
-- Double-click `.md` files in Project Explorer to open preview
-- GitHub-Flavored Markdown rendering via `marked`
-- Toggle between preview and edit modes
-- Full dark mode support
-
-### Diagnostics & Tasks (April 2025)
-- **DiagnosticsTask** system replaces legacy "punchlist"
-- **Suppression rules**: ignore specific diagnostics via `IgnoredDiagnosticRule` interface
-- **Sticky note promotion**: convert notes to tasks via checkbox
-- **Migration**: `migratePunchlistToTasks()` handles legacy data
-
-### Color Picker & Palette System (April 2025)
-- **ColorPickerPane** with four built-in palettes: Ren'Py Standard, HTML Named, Material 500, Pastel
-- **Project Theme palette**: auto-scans all `.rpy` files for hex colors via `useProjectColorScan` hook
-- **Draggable swatches**: drag colors onto `ColorDropTarget` components
-- **Actions**: Insert at cursor, Wrap in `{color}` tags, Copy hex
-
-### Menu Constructor (April 2025)
-Visual menu designer with:
-- Custom code block support per choice
-- Save/reuse menu templates via `MenuTemplate` interface
-- Action types: jump, call, pass, return, code
-- `MenuInspectorPanel` shows hover details on Route/Choice Canvas menu nodes
-
-### Project Refresh (April 2025)
-- **Refresh option** in File menu and Project Explorer context menu
-- `handleRefreshProject()` reconciles blocks/images/audios with disk state
-- Queues dirty-file conflict warnings
-- `project:refresh` IPC handler reads all file contents
+`RenpyAnalysisResult` is the central data structure — carries `labelNodes[]`, `routeLinks[]`, and `identifiedRoutes[]` for Flow/Choices Canvas rendering.
 
 ## Conventions
-- **Imports**: Use `@/` path alias for all source imports: `import { Block } from '@/types';` not `import { Block } from '../types';`. Avoid relative imports (`../`, `../../`) except for local sibling files.
-- **State mutation**: Always use `useImmer` drafts; never mutate state directly.
-- **IPC**: Use `namespace:action` pattern in both `preload.js` and `electron.js`.
-- **Modals**: Use `createPortal()` to `document.body` + the `useModalAccessibility` hook (focus trap, ESC, ARIA).
+- **Imports**: `@/` alias always. No `../` except local siblings.
+- **State mutation**: `useImmer` drafts only — never mutate state directly.
+- **IPC**: `namespace:action` pattern in both `preload.js` and `electron.js`.
+- **Modals**: `createPortal()` to `document.body` + `useModalAccessibility` hook (focus trap, ESC, ARIA).
 - **Styling**: Tailwind CSS + dark mode via `class` strategy.
+- **Canvas block components** (`CodeBlock`, `LabelBlock`, `GroupContainer`): `forwardRef` + `React.memo`. `.drag-handle` class initiates drag; `button`/`input` children do not propagate.
+- **Sticky notes**: Three arrays (`stickyNotes`, `routeStickyNotes`, `choiceStickyNotes`), one per canvas. Markdown via `marked`. Promotable to `DiagnosticsTask`.
+- **Color swatches**: Use `ColorDropTarget` for drag-and-drop color input.
 - **Clipboard UI**: Use `@/components/CopyButton`.
-- **Sticky notes**: Three separate arrays (`stickyNotes`, `routeStickyNotes`, `choiceStickyNotes`), one per canvas. Content renders as Markdown via `marked`. Notes can be promoted to `DiagnosticsTask` via checkbox.
-- **Color swatches**: Use `ColorDropTarget` component for drag-and-drop color input (wraps `<input type="color">`).
-- **Diagnostics tasks**: Use `DiagnosticsTask` interface (migrated from legacy "punchlist"). Tasks persist in `game/project.ide.json`.
-- **Tests**: Vitest + JSDOM. Setup in `src/test/setup.ts`. Test files match `**/*.test.{ts,tsx}`.
-- **Data models**: `src/types.ts` is the single source of truth for all interfaces (Block, Link, Diagnostic, Composition, etc.).
-- **Canvas drag**: Use native pointer events (`pointerdown`/`pointermove`/`pointerup`) with global listeners — do not use React synthetic events for drag performance.
-- **Components**: Canvas block components (`CodeBlock`, `LabelBlock`, `GroupContainer`) use `forwardRef` + `React.memo`. Elements with class `.drag-handle` initiate canvas drag; `button`/`input` children do not propagate drag.
+- **Data models**: `src/types.ts` is the single source of truth.
 
 ## Testing
-`src/test/mocks/electronAPI.ts` exports `createMockElectronAPI()` (fully-stubbed API with Promise defaults) and `installElectronAPI()` / `uninstallElectronAPI()` for test setup/teardown. `src/test/mocks/sampleData.ts` exports factory functions (`createBlock()`, `createBlockGroup()`, `createSampleAnalysisResult()`, `createAppSettings()`, etc.) used across unit and integration tests.
+Vitest + JSDOM. `src/test/mocks/electronAPI.ts` exports `createMockElectronAPI()`, `installElectronAPI()`, `uninstallElectronAPI()`. `src/test/mocks/sampleData.ts` has factory functions (`createBlock()`, `createSampleAnalysisResult()`, etc.). Test files match `**/*.test.{ts,tsx}`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "renide",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "renide",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@monaco-editor/react": "^4.6.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,7 +40,7 @@ import { SearchProvider } from '@/contexts/SearchContext';
 import StatsView from '@/components/StatsView';
 import TranslationDashboard from '@/components/TranslationDashboard';
 import GoToLabelModal, { GoToLabelItem } from '@/components/GoToLabelModal';
-import { useRenpyAnalysis } from '@/hooks/useRenpyAnalysis';
+import { useRenpyAnalysis, deriveSceneImageNames } from '@/hooks/useRenpyAnalysis';
 import { useHistory } from '@/hooks/useHistory';
 import { useProjectColorScan } from '@/hooks/useProjectColorScan';
 import { usePerformanceMetrics } from '@/hooks/usePerformanceMetrics';
@@ -643,14 +643,15 @@ const App: React.FC = () => {
   const routeRaw = useMemo(() => {
       const layoutMode = projectSettings.routeCanvasLayoutMode ?? 'flow-lr';
       const groupingMode = projectSettings.routeCanvasGroupingMode ?? 'none';
-      const layoutedNodes = computeRouteCanvasLayout(analysisResult.labelNodes, analysisResult.routeLinks, layoutMode, groupingMode);
+      const nodesWithScenes = deriveSceneImageNames(analysisResult.labelNodes, blocks);
+      const layoutedNodes = computeRouteCanvasLayout(nodesWithScenes, analysisResult.routeLinks, layoutMode, groupingMode);
       return {
           labelNodes: layoutedNodes,
           routeLinks: analysisResult.routeLinks,
           identifiedRoutes: analysisResult.identifiedRoutes,
           routesTruncated: analysisResult.routesTruncated,
       };
-  }, [analysisResult, projectSettings.routeCanvasGroupingMode, projectSettings.routeCanvasLayoutMode]);
+  }, [analysisResult, blocks, projectSettings.routeCanvasGroupingMode, projectSettings.routeCanvasLayoutMode]);
 
   const routeAnalysisResult = useMemo(() => {
       // Apply user-dragged position overrides on top of the auto-layout result.
@@ -4553,6 +4554,7 @@ const App: React.FC = () => {
         onWarpToLabel={handleWarpToLabel}
         centerOnStartRequest={centerOnRouteStartRequest}
         centerOnNodeRequest={centerOnRouteNodeRequest}
+        projectImages={images}
       />;
     }
     if (tab.type === 'choice-canvas') {

--- a/src/components/LabelBlock.tsx
+++ b/src/components/LabelBlock.tsx
@@ -22,6 +22,8 @@ interface LabelBlockProps {
   overlayHighlight?: 'hub' | 'branch' | 'menu-heavy' | 'call-heavy' | null;
   /** Numeric count shown inside the overlay badge (e.g. number of incoming links for hubs) */
   overlayCount?: number;
+  /** Resolved data URL for the scene image associated with this label (if any) */
+  sceneImageUrl?: string;
 }
 
 const OVERLAY_STYLES: Record<NonNullable<LabelBlockProps['overlayHighlight']>, {
@@ -45,6 +47,7 @@ const LabelBlock: React.FC<LabelBlockProps> = React.memo(({
   isDimmed,
   overlayHighlight,
   overlayCount,
+  sceneImageUrl,
 }) => {
 
   const overlayStyle = overlayHighlight ? OVERLAY_STYLES[overlayHighlight] : null;
@@ -91,6 +94,8 @@ const LabelBlock: React.FC<LabelBlockProps> = React.memo(({
     ? `\n${overlayStyle.title}${overlayCount !== undefined ? ` (${overlayCount})` : ''}`
     : '';
 
+  const hasThumbnail = node.sceneImageName !== undefined;
+
   return (
     <div
       data-label-node-id={node.id}
@@ -98,7 +103,7 @@ const LabelBlock: React.FC<LabelBlockProps> = React.memo(({
       role="button"
       aria-label={ariaLabel}
       aria-pressed={isSelected}
-      className={`group label-block-wrapper absolute rounded-md border-2 ${borderClass} ${shadowClass} ${bgClass} flex items-center px-3 space-x-2 cursor-grab transition-all duration-200 ${isDimmed ? 'opacity-20 pointer-events-none' : ''} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400`}
+      className={`group label-block-wrapper absolute rounded-md border-2 ${borderClass} ${shadowClass} ${bgClass} flex flex-col cursor-grab transition-all duration-200 ${isDimmed ? 'opacity-20 pointer-events-none' : ''} focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400 overflow-hidden`}
       style={{
         left: node.position.x,
         top: node.position.y,
@@ -111,18 +116,18 @@ const LabelBlock: React.FC<LabelBlockProps> = React.memo(({
       title={`Label: ${node.label}\nDouble-click to open in editor${roleTitle}`}
     >
         {isEntry && !isSelected && (
-          <span className="absolute -top-1.5 -left-1.5 w-3 h-3 rounded-full bg-green-500 border-2 border-white dark:border-gray-900 pointer-events-none" />
+          <span className="absolute -top-1.5 -left-1.5 w-3 h-3 rounded-full bg-green-500 border-2 border-white dark:border-gray-900 pointer-events-none z-10" />
         )}
         {isUnreachable && !isSelected && (
-          <span className="absolute -top-1.5 -left-1.5 w-3 h-3 rounded-full bg-orange-400 border-2 border-white dark:border-gray-900 pointer-events-none" />
+          <span className="absolute -top-1.5 -left-1.5 w-3 h-3 rounded-full bg-orange-400 border-2 border-white dark:border-gray-900 pointer-events-none z-10" />
         )}
         {isDeadEnd && !isSelected && (
-          <span className="absolute -top-1.5 -right-1.5 w-3 h-3 rounded-full bg-amber-500 border-2 border-white dark:border-gray-900 pointer-events-none" />
+          <span className="absolute -top-1.5 -right-1.5 w-3 h-3 rounded-full bg-amber-500 border-2 border-white dark:border-gray-900 pointer-events-none z-10" />
         )}
         {/* Overlay badge — bottom-left, shows count */}
         {overlayHighlight && overlayStyle && !isSelected && (
           <span
-            className={`absolute -bottom-1.5 -left-1.5 min-w-[14px] h-3.5 px-0.5 rounded-full ${overlayStyle.bg} border border-white dark:border-gray-900 pointer-events-none flex items-center justify-center`}
+            className={`absolute -bottom-1.5 -left-1.5 min-w-[14px] h-3.5 px-0.5 rounded-full ${overlayStyle.bg} border border-white dark:border-gray-900 pointer-events-none flex items-center justify-center z-10`}
             title={overlayStyle.title}
           >
             {overlayCount !== undefined && (
@@ -130,12 +135,49 @@ const LabelBlock: React.FC<LabelBlockProps> = React.memo(({
             )}
           </span>
         )}
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-gray-500 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M17.707 9.293a1 1 0 010 1.414l-7 7a1 1 0 01-1.414 0l-7-7A1 1 0 012 10V5a1 1 0 011-1h5a1 1 0 01.707.293l7 7zM5 6a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" /></svg>
-        <span className="text-sm font-semibold font-mono text-gray-800 dark:text-gray-200 truncate flex-1">
-            {node.label}
-        </span>
+
+        {/* Label row */}
+        <div className="flex items-center px-3 space-x-2 flex-shrink-0 border-b border-gray-200 dark:border-gray-700" style={{ height: 40 }}>
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 text-gray-500 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M17.707 9.293a1 1 0 010 1.414l-7 7a1 1 0 01-1.414 0l-7-7A1 1 0 012 10V5a1 1 0 011-1h5a1 1 0 01.707.293l7 7zM5 6a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" /></svg>
+          <span className="text-sm font-semibold font-mono text-gray-800 dark:text-gray-200 truncate flex-1">
+              {node.label}
+          </span>
+        </div>
+
+        {/* Scene thumbnail — 16:9 aspect ratio, full image visible */}
+        {hasThumbnail && (
+          <div
+            className="w-full flex-shrink-0 overflow-hidden"
+            style={{ height: node.height - 40 }}
+          >
+            {sceneImageUrl ? (
+              <img
+                src={sceneImageUrl}
+                alt={node.sceneImageName}
+                className="w-full h-full object-contain"
+                loading="lazy"
+                draggable={false}
+              />
+            ) : (
+              <div
+                className="w-full h-full flex flex-col items-center justify-center gap-1"
+                style={{
+                  background: 'repeating-linear-gradient(45deg, #e5e7eb, #e5e7eb 4px, #f3f4f6 4px, #f3f4f6 10px)',
+                }}
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clipRule="evenodd" />
+                </svg>
+                <span className="text-gray-500 font-mono leading-none px-1 text-center" style={{ fontSize: 7 }}>
+                  {node.sceneImageName}
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+
         <button
-          className="absolute top-0.5 right-0.5 opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded text-indigo-400 hover:text-indigo-600 dark:hover:text-indigo-300"
+          className="absolute top-0.5 right-0.5 opacity-0 group-hover:opacity-100 transition-opacity p-0.5 rounded text-indigo-400 hover:text-indigo-600 dark:hover:text-indigo-300 z-10"
           onClick={(e) => { e.stopPropagation(); onOpenEditor(node.blockId, node.startLine); }}
           onPointerDown={(e) => e.stopPropagation()}
           title="Open in editor"

--- a/src/components/RouteCanvas.tsx
+++ b/src/components/RouteCanvas.tsx
@@ -21,7 +21,7 @@ import StickyNoteComponent from './StickyNote';
 import CanvasContextMenu from './CanvasContextMenu';
 import CanvasNodeContextMenu from './CanvasNodeContextMenu';
 import type { MinimapItem } from './Minimap';
-import type { LabelNode, RouteLink, Position, IdentifiedRoute, MouseGestureSettings, StoryCanvasGroupingMode, StoryCanvasLayoutMode, StickyNote } from '@/types';
+import type { LabelNode, RouteLink, Position, IdentifiedRoute, MouseGestureSettings, StoryCanvasGroupingMode, StoryCanvasLayoutMode, StickyNote, ProjectImage } from '@/types';
 import { computeRouteCanvasLayout } from '@/lib/routeCanvasLayout';
 
 interface RouteCanvasProps {
@@ -30,6 +30,7 @@ interface RouteCanvasProps {
   identifiedRoutes: IdentifiedRoute[];
   routesTruncated?: boolean;
   stickyNotes: StickyNote[];
+  projectImages: Map<string, ProjectImage>;
   updateLabelNodePositions: (updates: { id: string, position: Position }[]) => void;
   onAddStickyNote: (position: Position) => void;
   updateStickyNote: (id: string, data: Partial<StickyNote>) => void;
@@ -321,6 +322,7 @@ const RouteCanvas: React.FC<RouteCanvasProps> = ({
   onWarpToLabel,
   centerOnStartRequest,
   centerOnNodeRequest,
+  projectImages,
 }) => {
   const [rubberBandRect, setRubberBandRect] = useState<Rect | null>(null);
   const [isDraggingSelection, setIsDraggingSelection] = useState(false);
@@ -368,6 +370,21 @@ const RouteCanvas: React.FC<RouteCanvasProps> = ({
   }, [rawRouteLinks, labelNodes]);
 
   const labelNodeMap = useMemo(() => new Map(labelNodes.map(n => [n.id, n])), [labelNodes]);
+
+  // Normalized scene-name → dataUrl lookup for thumbnail rendering.
+  // Ren'Py derives image tags from subpath after images/: "bg/academy_gate.png" → "bg academy_gate"
+  const sceneImageLookup = useMemo(() => {
+    const map = new Map<string, string>();
+    projectImages.forEach((img) => {
+      if (!img.dataUrl) return;
+      const imagesIdx = img.filePath.toLowerCase().indexOf('/images/');
+      if (imagesIdx === -1) return;
+      const rel = img.filePath.slice(imagesIdx + '/images/'.length);
+      const renpyTag = rel.replace(/\.[^.]+$/, '').replace(/\//g, ' ').toLowerCase();
+      map.set(renpyTag, img.dataUrl);
+    });
+    return map;
+  }, [projectImages]);
   const [canvasDimensions, setCanvasDimensions] = useState({ width: 0, height: 0 });
 
   // File-view graph: one node per file, one edge per cross-file transition
@@ -1998,6 +2015,10 @@ const RouteCanvas: React.FC<RouteCanvasProps> = ({
                 overlayCount = callHeavyData.counts.get(node.id);
               }
 
+              const sceneImageUrl = node.sceneImageName
+                ? sceneImageLookup.get(node.sceneImageName.toLowerCase())
+                : undefined;
+
               return (
                 <LabelBlock
                   key={node.id}
@@ -2012,6 +2033,7 @@ const RouteCanvas: React.FC<RouteCanvasProps> = ({
                   isDimmed={isNodeDimmed && !isSelected}
                   overlayHighlight={overlayHighlight}
                   overlayCount={overlayCount}
+                  sceneImageUrl={sceneImageUrl}
                 />
               );
             })

--- a/src/hooks/useRenpyAnalysis.ts
+++ b/src/hooks/useRenpyAnalysis.ts
@@ -36,6 +36,7 @@ const NARRATION_REGEX = /^\s*"(?!:)/;
 const SCREEN_REGEX = /^\s*screen\s+([a-zA-Z0-9_]+)\s*(\(.*\))?:/;
 const DEFINE_DEFAULT_REGEX = /^\s*(define|default)\s+([a-zA-Z0-9_.]+)\s*=\s*(?!\s*Character\s*\()(.+)/;
 const IMAGE_DEF_REGEX = /^\s*image\s+([a-zA-Z0-9_ ]+?)\s*=/;
+const SCENE_STATEMENT_REGEX = /^\s*scene\s+((?!expression\b)[a-zA-Z0-9_][a-zA-Z0-9_ ]*?)(?:\s+with\b|\s*(?:#|$))/;
 
 const PALETTE = [
   '#E57373', '#F06292', '#BA68C8', '#9575CD', '#7986CB', '#64B5F6',
@@ -514,6 +515,60 @@ const ROUTE_INITIAL_CONFIG: LayoutConfig = {
   crossAxisBase: 50,
 };
 
+const NODE_IMAGE_HEIGHT = 40 + Math.round(176 * 9 / 16); // label row + 16:9 image at 180px width
+
+/**
+ * Post-processes label nodes to attach scene image names derived from block content.
+ * Runs on the main thread so it always uses the latest code, bypassing the worker cache.
+ * Labels without their own `scene` statement inherit the last seen scene name from a
+ * prior label in the same file (forward propagation within each block).
+ */
+export function deriveSceneImageNames(nodes: LabelNode[], blocks: AnalysisBlock[]): LabelNode[] {
+  const blockContentMap = new Map(blocks.map(b => [b.id, b.content]));
+
+  const nodesByBlock = new Map<string, LabelNode[]>();
+  nodes.forEach(node => {
+    const arr = nodesByBlock.get(node.blockId) ?? [];
+    arr.push(node);
+    nodesByBlock.set(node.blockId, arr);
+  });
+
+  const updates = new Map<string, Partial<LabelNode>>();
+
+  nodesByBlock.forEach((blockNodes, blockId) => {
+    const content = blockContentMap.get(blockId);
+    if (!content) return;
+
+    const lines = content.split('\n');
+    const sorted = [...blockNodes].sort((a, b) => a.startLine - b.startLine);
+
+    let lastSceneName: string | undefined;
+    sorted.forEach((node, i) => {
+      const nextNode = sorted[i + 1];
+      const endLine = nextNode ? nextNode.startLine - 1 : lines.length;
+
+      let ownScene: string | undefined;
+      for (let j = node.startLine; j < endLine; j++) {
+        const m = (lines[j] ?? '').match(SCENE_STATEMENT_REGEX);
+        if (m) { ownScene = m[1].trim(); break; }
+      }
+
+      if (ownScene !== undefined) lastSceneName = ownScene;
+      const effective = ownScene ?? lastSceneName;
+
+      if (effective !== undefined) {
+        updates.set(node.id, { sceneImageName: effective, height: NODE_IMAGE_HEIGHT });
+      }
+    });
+  });
+
+  if (updates.size === 0) return nodes;
+  return nodes.map(n => {
+    const patch = updates.get(n.id);
+    return patch ? { ...n, ...patch } : n;
+  });
+}
+
 /** Hard cap on the number of routes enumerated to prevent exponential blowup. */
 const MAX_ROUTES = 500;
 /** Maximum recursion depth for path enumeration. */
@@ -591,7 +646,7 @@ export const performRouteAnalysis = (
         const nodeId = `${block.id}:${label}`;
         const node: LabelNode = {
             id: nodeId, label: label, blockId: block.id, containerName: block.title || block.filePath?.split('/').pop() || 'Untitled',
-            startLine: startLine, position: { x: 0, y: 0 }, width: 180, height: 40
+            startLine: startLine, position: { x: 0, y: 0 }, width: 180, height: 40,
         };
         labelNodes.set(nodeId, node);
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -467,6 +467,8 @@ export interface LabelNode {
   position: Position;
   width: number;
   height: number;
+  /** Image tag from the first `scene` statement in this label's body (e.g. "bg library") */
+  sceneImageName?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extracts the first `scene` statement from each label's body in `useRenpyAnalysis` (with forward-propagation for labels that inherit the previous scene in the same block)
- Resolves the scene name to a data URL using `projectImages` via a normalized Ren'Py tag lookup in `RouteCanvas`
- Renders a 16:9 thumbnail panel below the label row in `LabelBlock`; nodes without a scene stay at 40px height, nodes with one expand to fit the image. A hatched placeholder is shown while the URL is loading or missing.
- Trims `CLAUDE.md` from ~249 lines to ~89 — removes changelog entries and sections derivable from the code, keeps commands, state table, conventions, and canvas naming notes.

## Test plan
- [ ] Open a project with scene statements in `.rpy` files and verify thumbnails appear on Flow Canvas nodes
- [ ] Verify labels without `scene` statements render at original height with no thumbnail panel
- [ ] Verify forward-propagation: a label with no own `scene` inherits the last seen scene from a prior label in the same file
- [ ] Verify the hatched placeholder renders when a scene name has no matching image in `projectImages`
- [ ] Verify Choices Canvas and Project Canvas are unaffected
- [ ] Check dark mode rendering of the thumbnail border and placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)