### PR TITLE
Stop electron-builder auto-publishing stray draft releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,12 @@ jobs:
         run: npm ci
 
       - name: Build and Package
-        run: npm run dist
+        # --publish=never: this workflow only has `contents: read`, which
+        # already blocks electron-builder's own auto-publish attempt (see
+        # release.yml's identical flag for the full explanation) -- passed
+        # here too so a future permissions change doesn't silently re-enable
+        # stray draft releases from routine PR/main builds.
+        run: npm run dist -- --publish=never
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,7 +65,11 @@ jobs:
         run: npm ci
 
       - name: Build and package
-        run: npm run dist
+        # --publish=never: see release.yml's identical flag -- electron-builder
+        # otherwise tries to auto-publish itself (package.json's build.publish
+        # config) independent of this workflow's own "Publish Nightly Release"
+        # step, creating a stray draft release per run.
+        run: npm run dist -- --publish=never
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,15 @@ jobs:
         run: npm ci
 
       - name: Build and package
-        run: npm run dist
+        # --publish=never: package.json's build.publish (provider: github) makes
+        # electron-builder try to auto-publish itself whenever a GITHUB_TOKEN is
+        # present, independent of and in addition to this workflow's own
+        # softprops/action-gh-release publish step below. Left enabled, every
+        # platform in this matrix created/appended to its own stray draft
+        # release named after package.json's version (not this run's git tag),
+        # using electron-updater metadata (latest.yml etc.) our workflow
+        # doesn't use -- confirmed happening on the v1.0.0-rc1 run.
+        run: npm run dist -- --publish=never
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- `package.json`'s `build.publish` config (provider: `github`) makes electron-builder try to publish itself during `npm run dist` whenever `GITHUB_TOKEN` is present — independent of and in addition to each workflow's own explicit publish step
- Confirmed on the `v1.0.0-rc1` release run: each of the 4 platform matrix jobs created/appended to a stray draft release named `1.0.0` (from `package.json`'s version, not the triggering git tag), carrying `electron-updater` metadata this project doesn't use. Deleted that stray draft manually.
- Since it keys off the version rather than the tag, every RC build would collide into the same draft, silently mixing artifacts from different commits — a real correctness risk, not just clutter
- Added `--publish=never` to the `npm run dist` invocation in `release.yml`, `nightly.yml` (both have `contents: write`, both exposed), and `build.yml` (already blocked by `contents: read`, added for defense-in-depth)

## Test plan
- [x] YAML syntax validated for all three workflow files
- [ ] Next tagged release run publishes only the one intended release (no stray draft appears)

🤖 Generated with [Claude Code](https://claude.com/claude-code)