### PR TITLE
fix: address recurring main-branch build failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,14 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Disable Spotlight indexing (macOS)
+        # electron-builder's dmgbuild step intermittently fails to eject the
+        # freshly-built DMG with "Resource busy" -- caused by mds/mdworker
+        # racing to index the just-mounted volume before it detaches. Turning
+        # indexing off removes that race instead of retrying around it.
+        if: runner.os == 'macOS'
+        run: sudo mdutil -a -i off
+
       - name: Build and Package
         # --publish=never: this workflow only has `contents: read`, which
         # already blocks electron-builder's own auto-publish attempt (see
@@ -80,10 +88,21 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
+          # Defender's real-time scan of a freshly-built, unsigned installer has been
+          # observed to stall the silent install for 6+ minutes with nothing ever
+          # landing on disk (vs. ~15s normally) -- disabling it here removes that
+          # variable instead of chasing an intermittent multi-minute hang.
+          Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
+
           $installer = Get-ChildItem release/*.exe | Select-Object -First 1
           if (-not $installer) { Write-Error "No .exe installer found in release/"; exit 1 }
           Write-Host "Running installer: $($installer.FullName)"
-          Start-Process -FilePath $installer.FullName -ArgumentList "/S" -Wait
+          $installProc = Start-Process -FilePath $installer.FullName -ArgumentList "/S" -PassThru
+          if (-not $installProc.WaitForExit(120000)) {
+            Write-Error "Installer did not finish within 120s -- killing it"
+            $installProc.Kill()
+            exit 1
+          }
 
           # Silent NSIS installs can land per-user (%LOCALAPPDATA%\Programs) or
           # per-machine (%ProgramFiles%) depending on the assisted-install default,

--- a/src/components/UserSnippetModal.tsx
+++ b/src/components/UserSnippetModal.tsx
@@ -44,9 +44,17 @@ const UserSnippetModal: React.FC<UserSnippetModalProps> = ({ isOpen, onClose, on
         setUsePlaceholders(false);
       }
       setError('');
-      setTimeout(() => titleInputRef.current?.focus(), 50);
+      // Guard against stealing focus back from a field the user has already
+      // started typing into -- without this, a user (or fast automated
+      // input) interacting with the modal within the first 50ms loses
+      // keystrokes to the title field when this fires.
+      setTimeout(() => {
+        if (!contentRef.current?.contains(document.activeElement)) {
+          titleInputRef.current?.focus();
+        }
+      }, 50);
     }
-  }, [isOpen, existingSnippet]);
+  }, [isOpen, existingSnippet, contentRef]);
 
   const handleSave = () => {
     const trimmedTitle = title.trim();


### PR DESCRIPTION
## Summary
Audited the last 30 `build.yml` runs on `main`: 43% failure rate across three distinct, reproducible causes.

- **Build on windows-latest** (7/13 failures): installer smoke test's silent NSIS install (`/S`) sometimes hangs 6+ minutes with nothing landing on disk (vs. ~15s normally). Timing matches Defender's real-time scan of the freshly-built, unsigned installer. Disabled real-time monitoring before running it, and bounded the wait to 120s so a future hang fails fast with a clear message.
- **Build on macos-15-intel** (3/13 failures): electron-builder's dmgbuild step intermittently threw `Unable to detach device cleanly: ... Resource busy` — Spotlight indexing racing the DMG eject. Disabled Spotlight indexing before packaging.
- **Test & Lint on macos-latest** (6/13 failures): `UserSnippetModal.test.tsx`'s "shows error when code is empty" consistently failed on macOS's slower runners. A `setTimeout(..., 50)` unconditionally refocuses the title field on mount, racing the test's typing into the prefix field and hijacking keystrokes back into the title field (`value="Testtst"` in the failure DOM dump), leaving prefix empty so the modal showed the wrong error. Same race could bite a real user typing within 50ms of the modal opening. Fixed by only stealing focus if nothing in the modal already has it.

## Test plan
- [x] `npx vitest run src/components/UserSnippetModal.test.tsx` — 10/10 passing
- [x] `npm test -- --run` — 2104/2104 passing
- [x] `npx eslint src/components/UserSnippetModal.tsx` — clean
- [ ] CI green on this PR across all matrix jobs (windows/ubuntu/macos/macos-15-intel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)