### PR TITLE
fix: show app version in the window title

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -173,9 +173,9 @@ const App: React.FC = () => {
   // Update window title based on project path
   useEffect(() => {
     if (projectRootPath) {
-      document.title = `Vangard Studio (${projectRootPath})`;
+      document.title = `Vangard Studio ${process.env.APP_VERSION} (${projectRootPath})`;
     } else {
-      document.title = "Vangard Studio";
+      document.title = `Vangard Studio ${process.env.APP_VERSION}`;
     }
   }, [projectRootPath]);
 

--- a/src/test/App.test.tsx
+++ b/src/test/App.test.tsx
@@ -72,11 +72,11 @@ describe('App', () => {
   // ── Window title ───────────────────────────────────────────────────────────
 
   describe('window title', () => {
-    it('is "Vangard Studio" when no project is open', async () => {
+    it('includes the app version when no project is open', async () => {
       renderApp();
       // title effect fires after render
       await waitFor(() => {
-        expect(document.title).toBe('Vangard Studio');
+        expect(document.title).toBe(`Vangard Studio ${process.env.APP_VERSION}`);
       });
     });
   });


### PR DESCRIPTION
## Summary
- The version was only visible in the About dialog or a small line in StatusBar's bottom-right corner — easy to miss.
- The window title (title bar, taskbar hover tooltip, Alt-Tab/Cmd-Tab switcher) now reads `Vangard Studio 1.0.0` (and `Vangard Studio 1.0.0 (path/to/project)` when a project is open), using the same `process.env.APP_VERSION` StatusBar already relies on.
- Deliberately left `productName`/`CFBundleName` (the static Start Menu/Dock/taskbar-icon label set at install time) alone — embedding the version there would make every upgrade create a new/duplicate shortcut instead of updating in place, and Electron's default `userData` path is derived from the app name, so a version-suffixed name would reset user settings on every update.

## Test plan
- [x] `npm test -- --run` — 2104/2104 passing
- [x] Updated `App.test.tsx`'s window-title test to assert the version is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)